### PR TITLE
Feat[Icon]: 아이콘 컴포넌트 작업

### DIFF
--- a/src/components/common/Icon/Icon.tsx
+++ b/src/components/common/Icon/Icon.tsx
@@ -4,16 +4,40 @@ export type Props = {
   icon: IconType;
   size?: number;
   className?: string;
+  ariaLabel?: string;
+  role?: string;
 } & React.SVGProps<SVGSVGElement>;
 
-const Icon = ({ icon, size, className, ...props }: Props) => {
+const Icon = ({ icon, size, className, ariaLabel, role, ...props }: Props) => {
   const IconSVGComponent = iconMap[icon];
 
-  return (
-    <span>
-      <IconSVGComponent width={size} height={size} className={className} {...props} />
-    </span>
-  );
+  {
+    /* 🔤 아무런 인터랙션없이 단지 이미지식의 아이콘일 경우만
+    ariaLabel, role을 prop으로 주시면 됩니다
+    */
+  }
+  {
+    /* 🔤 인터랙션이 있는 아이콘인 경우에는
+      ariaLabel, role을 prop으로 주지 않고, 이벤트가 달리는 버튼이나 인풋의 속성으로 주시면 됩니다
+      해당 아이콘에도 접근성정보를 넣으면 중복으로 읽히는 문제가 발생할 수 있습니다
+      */
+  }
+
+  const accessibilityProps = ariaLabel
+    ? {
+        role: role ?? 'img',
+        'aria-label': ariaLabel,
+      }
+    : {
+        'aria-hidden': true,
+      };
+
+  {
+    /* 🔤 아이콘 color값을 tailwindcss 속성으로 사용하기 위해 
+    color를 prop으로 받지 않고, className으로 전달
+    (아이콘 컴포넌트에 color가 들어가는 부분을 currentColor로 변경해주세요.) */
+  }
+  return <IconSVGComponent width={size} height={size} className={className} {...accessibilityProps} {...props} />;
 };
 
 export default Icon;

--- a/src/components/common/Icon/Icon.tsx
+++ b/src/components/common/Icon/Icon.tsx
@@ -1,0 +1,19 @@
+import { iconMap, IconType } from '@/components/common/Icon/assets';
+
+export type Props = {
+  icon: IconType;
+  size?: number;
+  className?: string;
+} & React.SVGProps<SVGSVGElement>;
+
+const Icon = ({ icon, size, className, ...props }: Props) => {
+  const IconSVGComponent = iconMap[icon];
+
+  return (
+    <span>
+      <IconSVGComponent width={size} height={size} className={className} {...props} />
+    </span>
+  );
+};
+
+export default Icon;

--- a/src/components/common/Icon/assets/AlertCircle.tsx
+++ b/src/components/common/Icon/assets/AlertCircle.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+const AlertCircle = ({ width, height, className, ...props }: React.SVGProps<SVGSVGElement>) => {
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      {...props}
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M12 2.75C6.89137 2.75 2.75 6.89137 2.75 12C2.75 17.1086 6.89137 21.25 12 21.25C17.1086 21.25 21.25 17.1086 21.25 12C21.25 6.89137 17.1086 2.75 12 2.75ZM1.25 12C1.25 6.06294 6.06294 1.25 12 1.25C17.9371 1.25 22.75 6.06294 22.75 12C22.75 17.9371 17.9371 22.75 12 22.75C6.06294 22.75 1.25 17.9371 1.25 12Z"
+        fill="currentColor"
+      />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M12 6.48303C12.4142 6.48303 12.75 6.81882 12.75 7.23303V13.8961C12.75 14.3103 12.4142 14.6461 12 14.6461C11.5858 14.6461 11.25 14.3103 11.25 13.8961V7.23303C11.25 6.81882 11.5858 6.48303 12 6.48303Z"
+        fill="currentColor"
+      />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M12 15.663C12.4142 15.663 12.75 15.9988 12.75 16.413V16.8805C12.75 17.2947 12.4142 17.6305 12 17.6305C11.5858 17.6305 11.25 17.2947 11.25 16.8805V16.413C11.25 15.9988 11.5858 15.663 12 15.663Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+};
+
+export default AlertCircle;

--- a/src/components/common/Icon/assets/index.ts
+++ b/src/components/common/Icon/assets/index.ts
@@ -1,0 +1,8 @@
+import AlertCircle from '@/components/common/Icon/assets/AlertCircle';
+
+export const iconMap = {
+  alertCircle: AlertCircle,
+};
+
+export type IconType = keyof typeof iconMap;
+export const iconList = Object.keys(iconMap) as IconType[];


### PR DESCRIPTION
## 유형

- [x] 기능 구현
- [ ] UI 구현
- [ ] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

- 각 icon을 컴포넌트로 작성하고, 컴포넌트들을 Map객체로 관리하는 모듈작성
- Map객체의 key값을 prop ```icon``` 으로 전달하여 사용할 수 있게 작성


### 설명 (선택)

- 컬러를 prop으로 받지않고 currentColor를 통해 className으로 전달한 색으로 적용 (tailwind 속성 사용을 위해)
- ```/Icon/assets``` 폴더에 컴포넌트 형식으로 아이콘을 정의하고, iconMap에 추가하여 Icon컴포넌트의 icon prop으로 전달해서 사용

## 스크린샷

![image](https://github.com/user-attachments/assets/8f693b07-f551-44ba-a9a2-3584a89c28f7)

## 리뷰 요구사항

