### PR TITLE
Feat[HelpMessage]: HelpMessage 컴포넌트 구현

### DIFF
--- a/src/components/common/HelpMessage.tsx
+++ b/src/components/common/HelpMessage.tsx
@@ -1,0 +1,50 @@
+import Icon from '@/components/common/Icon/Icon';
+import Typography, { TypographyProps } from '@/components/common/Typography';
+import clsx from 'clsx';
+import React from 'react';
+
+// props 정의: Typography에서 type과 children은 제외하고,
+// title(텍스트)과 상태(status)를 추가로 받음
+interface HelpMessageProps extends Omit<TypographyProps, 'type' | 'children'> {
+  title: string;
+  status?: 'default' | 'error' | 'success';
+}
+
+// 상태별 텍스트 색상 클래스 정의
+const statusClasses = {
+  default: 'text-gray-50',
+  error: 'text-danger-50',
+  success: 'text-success-50',
+};
+
+const HelpMessage = ({ title, status = 'default', ...props }: HelpMessageProps) => {
+  return (
+    <Typography
+      // 기본적으로 Body3Medium 텍스트 스타일 사용
+      type="Body3Medium"
+      // 에러 상태일 경우, 스크린 리더가 즉시 읽도록 role과 aria-live 추가
+      role={status === 'error' ? 'alert' : undefined}
+      aria-live={status === 'error' ? 'assertive' : status === 'success' ? 'polite' : undefined}
+      // 상태에 따라 텍스트 색상과 레이아웃 클래스 적용
+      className={clsx('flex h-space-24 w-fit gap-1 items-center', statusClasses[status])}
+      {...props}
+    >
+      {/* 에러 상태일 때 아이콘 렌더링, 시각적 표시만 하고 스크린리더는 무시 */}
+      {status === 'error' && (
+        <Icon icon="alertCircle" width={20} className={statusClasses[status]} aria-hidden="true" />
+      )}
+
+      {/* 성공 상태일 때 아이콘 렌더링, 역시 시각적 표시만 하고 스크린리더는 무시 */}
+      {status === 'success' && (
+        <div className="size-space-20 p-1">
+          <Icon aria-hidden="true" icon="check" className={statusClasses[status]} />
+        </div>
+      )}
+
+      {/* 텍스트 메시지 출력 */}
+      {title}
+    </Typography>
+  );
+};
+
+export default HelpMessage;

--- a/src/components/common/Typography.tsx
+++ b/src/components/common/Typography.tsx
@@ -107,7 +107,7 @@ type TypographyTag = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'span';
 type TypographyType = keyof typeof TypographyTypes;
 
 // 🎁 이 컴포넌트가 받을 수 있는 모든 속성들을 정의해요
-type TypographyProps = {
+export type TypographyProps = {
   tag?: TypographyTag; // 어떤 태그로 보여줄지 (h1, p, span 등)
   children: ReactNode; // 보여줄 내용
   type: TypographyType;


### PR DESCRIPTION
## 유형

- [ ] 기능 구현
- [x] UI 구현
- [ ] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용
- HelpMessage 컴포넌트 구현

## 스크린샷
![스크린샷 2025-04-17 12 06 50](https://github.com/user-attachments/assets/d2d4bf97-0ee9-4bc3-99e2-9609588cf0bf)
![스크린샷 2025-04-17 12 06 57](https://github.com/user-attachments/assets/747ab000-06e1-47d0-b3d0-ddbf2d2d547a)


## 리뷰 요구사항
- text-success-50(base)의 색상이 너무 밝은 것 같지 않나요?