### PR TITLE
Feat[storybook]: 할당된 컴포넌트 storybook화 및 자잘한 버그 수정(Label)

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -10,6 +10,9 @@ const preview: Preview = {
         date: /Date$/i,
       },
     },
+    nextjs: {
+      appDirectory: true,
+    },
   },
 };
 

--- a/src/components/common/CheckBox.tsx
+++ b/src/components/common/CheckBox.tsx
@@ -8,6 +8,11 @@ interface CheckBoxProps extends InputHTMLAttributes<HTMLInputElement> {
 }
 
 const CheckBox = ({ error, ...props }: CheckBoxProps) => {
+  // 만약 disable 일때
+  if (props.disabled) {
+    // error style 꺼주기
+    error = false;
+  }
   return (
     // 그룹 클래스를 통해 자식 요소에 상태에 따라 스타일링 적용 가능
     <div className="group">
@@ -19,8 +24,8 @@ const CheckBox = ({ error, ...props }: CheckBoxProps) => {
            hover:border-gray-40 active:border-gray-50 
            group-has-[input:checked]:border-info-50 group-has-[input:checked]:bg-info-50 
            group-has-[input:checked]:hover:bg-info-60 group-has-[input:checked]:hover:border-info-60 
-           group-has-[input:checked]:active:bg-info-70 group-has-[input:checked]:active:border-info-70 
-           group-has-[input:disabled]:!bg-gray-30 group-has-[input:disabled]:!border-gray-40`,
+           group-has-[input:checked]:active:bg-info-70 group-has-[input:checked]:active:border-info-70,
+          group-has-[input:disabled]:!bg-gray-30 group-has-[input:disabled]:!border-gray-40`,
           error && '!border-danger-50 !bg-white', // 에러 시 스타일 오버라이드
         )}
       >

--- a/src/components/common/Label.tsx
+++ b/src/components/common/Label.tsx
@@ -1,45 +1,40 @@
 import Typography from '@/components/common/Typography';
+import clsx from 'clsx';
 import React, { LabelHTMLAttributes } from 'react';
+import { optional } from 'zod';
 
+const statusValue = {
+  optional: { text: 'text-gray-60', title: '(optional)', screenReaderText: '선택 항목입니다.' },
+  require: { text: 'text-danger-50', title: '*', screenReaderText: '필수 항목입니다.' },
+};
 interface LabelProps extends LabelHTMLAttributes<HTMLLabelElement> {
   // 표시할 라벨 텍스트
   title: string;
   // 선택 사항 여부 (선택적으로 표시)
-  optional?: boolean;
-  // 필수 여부 (* 표시용)
-  require?: boolean;
+  status?: keyof typeof statusValue | 'default';
 }
 
-const Label = ({ title, optional = false, require = false, ...props }: LabelProps) => {
-  // optional과 require가 동시에 true일 경우 경고 출력
-  if (optional && require) {
-    const isDevMode = process.env.NODE_ENV === 'development';
-    if (isDevMode) console.warn('Label 컴포넌트에 optional과 require가 동시에 true입니다.');
-  }
-
+const Label = ({ title, status = 'default', ...props }: LabelProps) => {
   return (
     // input과 연결되는 label 태그
     <label {...props}>
       <Typography type="Body1Medium" className="text-gray-60">
         {title}
         {/* optional 텍스트는 스크린 리더에 읽히지 않도록 aria-hidden */}
-        {optional && (
+        {status !== 'default' && (
           <>
-            <span className="sr-only">선택 항목입니다.</span>
-            <Typography type="Body1Medium" tag="span" className="ml-1 text-gray-60" aria-hidden="true">
-              (optional)
+            <span className="sr-only">{statusValue[status].screenReaderText}</span>
+            <Typography
+              type="Body1Medium"
+              tag="span"
+              className={clsx('ml-1', statusValue[status].text)}
+              aria-hidden="true"
+            >
+              {statusValue[status].title}
             </Typography>
           </>
         )}
         {/* require 텍스트(*) 역시 시각적인 강조를 위한 요소로, 스크린 리더는 무시 */}
-        {require && (
-          <>
-            <span className="sr-only">필수 항목입니다.</span>
-            <Typography type="Body1Medium" tag="span" className="ml-1 text-danger-50" aria-hidden="true">
-              *
-            </Typography>
-          </>
-        )}
       </Typography>
     </label>
   );

--- a/src/components/common/Label.tsx
+++ b/src/components/common/Label.tsx
@@ -1,7 +1,6 @@
 import Typography from '@/components/common/Typography';
 import clsx from 'clsx';
 import React, { LabelHTMLAttributes } from 'react';
-import { optional } from 'zod';
 
 const statusValue = {
   optional: { text: 'text-gray-60', title: '(optional)', screenReaderText: '선택 항목입니다.' },
@@ -20,7 +19,6 @@ const Label = ({ title, status = 'default', ...props }: LabelProps) => {
     <label {...props}>
       <Typography type="Body1Medium" className="text-gray-60">
         {title}
-        {/* optional 텍스트는 스크린 리더에 읽히지 않도록 aria-hidden */}
         {status !== 'default' && (
           <>
             <span className="sr-only">{statusValue[status].screenReaderText}</span>
@@ -34,7 +32,6 @@ const Label = ({ title, status = 'default', ...props }: LabelProps) => {
             </Typography>
           </>
         )}
-        {/* require 텍스트(*) 역시 시각적인 강조를 위한 요소로, 스크린 리더는 무시 */}
       </Typography>
     </label>
   );

--- a/src/components/common/Typography.tsx
+++ b/src/components/common/Typography.tsx
@@ -40,7 +40,7 @@ const sizeClasses = {
   '6xs': 'text-6xs', // 초미니 사이즈
 };
 
-const TypographyTypes = {
+export const TypographyTypes = {
   Display1Regular: clsx(sizeClasses['6xl'], weightClasses['normal']),
   Display1Medium: clsx(sizeClasses['6xl'], weightClasses['medium']),
   Display1Bold: clsx(sizeClasses['6xl'], weightClasses['bold']),

--- a/src/components/common/pagination/DotPagination.tsx
+++ b/src/components/common/pagination/DotPagination.tsx
@@ -9,13 +9,13 @@ import clsx from 'clsx';
 // - totalDots: 도트의 총 개수
 // - activeDot: 현재 활성화된 도트 index (0부터 시작)
 // - col: true일 경우 세로 방향 정렬 (기본은 가로 정렬)
-interface DotPaginationProps extends DotProps {
+interface DotPaginationProps extends Omit<DotProps, 'active'> {
   totalDots: number;
   activeDot: number;
   col?: boolean;
 }
 
-const DotPagination: React.FC<DotPaginationProps> = ({ totalDots, activeDot, col, ...props }) => {
+const DotPagination = ({ totalDots, activeDot, col, ...props }: DotPaginationProps) => {
   // 🎯 도트를 총 개수만큼 생성
   // - 각 도트의 index가 activeDot과 같으면 active 상태로 렌더링
   const generateDotPagination = Array.from({ length: totalDots }, (_, i) => {

--- a/src/stories/CheckBox.stories.ts
+++ b/src/stories/CheckBox.stories.ts
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import CheckBox from '@/components/common/CheckBox';
+
+const meta = {
+  title: 'Components/CheckBox',
+  component: CheckBox,
+  tags: ['autodocs'],
+  argTypes: {
+    checked: {
+      control: 'boolean',
+    },
+    disabled: {
+      control: 'boolean',
+    },
+    error: {
+      control: 'boolean',
+    },
+    id: {
+      control: 'text',
+    },
+    onChange: { action: 'changed' }, // 이벤트 추적용
+  },
+} satisfies Meta<typeof CheckBox>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  args: {
+    id: 'checkbox-story',
+    checked: false,
+    error: false,
+    disabled: false,
+  },
+};

--- a/src/stories/HelpMessage.stories.ts
+++ b/src/stories/HelpMessage.stories.ts
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import HelpMessage from '@/components/common/HelpMessage';
+
+const meta = {
+  title: 'Components/HelpMessage',
+  component: HelpMessage,
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      control: 'text',
+    },
+    status: {
+      control: 'select',
+      options: ['default', 'error', 'success'],
+    },
+    className: {
+      control: 'text',
+    },
+  },
+} satisfies Meta<typeof HelpMessage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  args: {
+    title: '비밀번호는 8자 이상 입력해야 해요.',
+    status: 'error',
+  },
+};
+
+export const Default: Story = {
+  args: {
+    title: '비밀번호는 8자 이상 입력해야 해요.',
+  },
+};
+
+export const Error: Story = {
+  args: {
+    title: '비밀번호는 8자 이상 입력해야 해요.',
+    status: 'error',
+  },
+};
+
+export const Success: Story = {
+  args: {
+    title: '비밀번호는 8자 이상 입력해야 해요.',
+    status: 'success',
+  },
+};

--- a/src/stories/Label.stories.ts
+++ b/src/stories/Label.stories.ts
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import Label from '@/components/common/Label';
+
+const meta = {
+  title: 'Components/Label',
+  component: Label,
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      control: 'text',
+    },
+    optional: {
+      control: 'boolean',
+    },
+    require: {
+      control: 'boolean',
+    },
+    htmlFor: {
+      control: 'text',
+    },
+  },
+} satisfies Meta<typeof Label>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  args: {
+    title: '이메일',
+    optional: false,
+    require: true,
+    htmlFor: 'email',
+  },
+};
+export const Default: Story = {
+  args: {
+    title: '이메일',
+    optional: false,
+    require: false,
+    htmlFor: 'email',
+  },
+};
+export const Optional: Story = {
+  args: {
+    title: '이메일',
+    optional: true,
+    require: false,
+    htmlFor: 'email',
+  },
+};
+
+export const Require: Story = {
+  args: {
+    title: '이메일',
+    optional: false,
+    require: true,
+    htmlFor: 'email',
+  },
+};

--- a/src/stories/Label.stories.ts
+++ b/src/stories/Label.stories.ts
@@ -8,15 +8,16 @@ const meta = {
   argTypes: {
     title: {
       control: 'text',
+      description: '라벨 텍스트',
     },
-    optional: {
-      control: 'boolean',
-    },
-    require: {
-      control: 'boolean',
+    status: {
+      control: { type: 'radio' },
+      options: ['default', 'optional', 'require'],
+      description: `'optional', 'require', 'default' 중 하나`,
     },
     htmlFor: {
       control: 'text',
+      description: '연결할 input의 id',
     },
   },
 } satisfies Meta<typeof Label>;
@@ -27,24 +28,23 @@ type Story = StoryObj<typeof meta>;
 export const Playground: Story = {
   args: {
     title: '이메일',
-    optional: false,
-    require: true,
+    status: 'default',
     htmlFor: 'email',
   },
 };
+
 export const Default: Story = {
   args: {
     title: '이메일',
-    optional: false,
-    require: false,
+    status: 'default',
     htmlFor: 'email',
   },
 };
+
 export const Optional: Story = {
   args: {
     title: '이메일',
-    optional: true,
-    require: false,
+    status: 'optional',
     htmlFor: 'email',
   },
 };
@@ -52,8 +52,7 @@ export const Optional: Story = {
 export const Require: Story = {
   args: {
     title: '이메일',
-    optional: false,
-    require: true,
+    status: 'require',
     htmlFor: 'email',
   },
 };

--- a/src/stories/Typography.stories.ts
+++ b/src/stories/Typography.stories.ts
@@ -1,0 +1,32 @@
+import Typography, { TypographyTypes } from '@/components/common/Typography';
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+
+const meta = {
+  title: 'Components/Typography',
+  component: Typography,
+  args: { onClick: fn() },
+  tags: ['autodocs'],
+  argTypes: {
+    tag: {
+      control: 'select',
+      options: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'span'],
+    },
+    type: {
+      control: 'select',
+      options: Object.keys(TypographyTypes),
+    },
+  },
+} satisfies Meta<typeof Typography>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  args: {
+    tag: 'h3',
+    type: 'Title3Medium',
+    children: '이것은 Typography 예시입니다.',
+    className: 'text-danger-50',
+  },
+};

--- a/src/stories/pagination/ChevronIconButton.stories.ts
+++ b/src/stories/pagination/ChevronIconButton.stories.ts
@@ -1,0 +1,28 @@
+import ChevronIconButton from '@/components/common/pagination/ChevronIconButton';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'Components/Pagination/ChevronIconButton',
+  component: ChevronIconButton,
+  tags: ['autodocs'],
+  argTypes: {
+    direction: {
+      control: 'radio',
+      options: ['left', 'right'],
+    },
+    disabled: {
+      control: 'boolean',
+    },
+    onClick: { action: 'clicked' },
+  },
+} satisfies Meta<typeof ChevronIconButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  args: {
+    direction: 'right',
+    disabled: false,
+  },
+};

--- a/src/stories/pagination/Dot.stories.ts
+++ b/src/stories/pagination/Dot.stories.ts
@@ -1,0 +1,23 @@
+import Dot from '@/components/common/pagination/Dot';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'Components/Pagination/Dot',
+  component: Dot,
+  tags: ['autodocs'],
+  argTypes: {
+    active: {
+      control: 'boolean',
+    },
+    onClick: { action: 'clicked' }, // 클릭 테스트 가능
+  },
+} satisfies Meta<typeof Dot>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  args: {
+    active: false,
+  },
+};

--- a/src/stories/pagination/DotPagination.stories.ts
+++ b/src/stories/pagination/DotPagination.stories.ts
@@ -1,0 +1,31 @@
+import DotPagination from '@/components/common/pagination/DotPagination';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'Components/Pagination/DotPagination',
+  component: DotPagination,
+  tags: ['autodocs'],
+  argTypes: {
+    totalDots: {
+      control: { type: 'number', min: 1 },
+    },
+    activeDot: {
+      control: { type: 'number', min: 0 },
+    },
+    col: {
+      control: 'boolean',
+    },
+    onClick: { action: 'clicked' },
+  },
+} satisfies Meta<typeof DotPagination>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  args: {
+    totalDots: 5,
+    activeDot: 2,
+    col: false,
+  },
+};

--- a/src/stories/pagination/Pagination.stories.ts
+++ b/src/stories/pagination/Pagination.stories.ts
@@ -1,0 +1,64 @@
+import Pagination from '@/components/common/pagination/Pagination';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof Pagination> = {
+  title: 'Components/Pagination/Pagination',
+  component: Pagination,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    totalPage: {
+      control: { type: 'number', min: 1 },
+      description: '전체 페이지 수',
+    },
+    activePage: {
+      control: { type: 'number', min: 1 },
+      description: '현재 활성화된 페이지 번호',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Pagination>;
+
+// 기본 스토리
+export const Default: Story = {
+  args: {
+    totalPage: 20,
+    activePage: 1,
+  },
+};
+
+// 중간 페이지 활성화 상태
+export const MiddlePage: Story = {
+  args: {
+    totalPage: 20,
+    activePage: 10,
+  },
+};
+
+// 마지막 페이지 활성화 상태
+export const LastPage: Story = {
+  args: {
+    totalPage: 20,
+    activePage: 20,
+  },
+};
+
+// 페이지가 적은 경우
+export const FewPages: Story = {
+  args: {
+    totalPage: 5,
+    activePage: 3,
+  },
+};
+
+// 많은 페이지가 있는 경우
+export const ManyPages: Story = {
+  args: {
+    totalPage: 100,
+    activePage: 50,
+  },
+};

--- a/src/stories/pagination/PaginationNumberButton.stories.ts
+++ b/src/stories/pagination/PaginationNumberButton.stories.ts
@@ -1,0 +1,28 @@
+import PaginationNumberButton from '@/components/common/pagination/PaginationNumberButton';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+  title: 'Components/Pagination/NumberButton',
+  component: PaginationNumberButton,
+  tags: ['autodocs'],
+  argTypes: {
+    active: {
+      control: 'boolean',
+    },
+    onClick: { action: 'clicked' },
+    children: {
+      control: 'text',
+      defaultValue: '1',
+    },
+  },
+} satisfies Meta<typeof PaginationNumberButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  args: {
+    active: false,
+    children: '1',
+  },
+};


### PR DESCRIPTION
## 유형

- [x] 기능 구현
- [x] UI 구현
- [ ] 리팩토링
- [x] 버그 해결
- [x] 문서 업데이트
- [ ] 기타

## 작업 내용

- [기능 구현] Storybook의 Next.js App Directory 관련 속성 업데이트.
- [UI 구현] 주간 작업 컴포넌트를 Storybook으로 문서화.
- [문서 업데이트] Storybook에서 사용할 변수 export 및 문법 수정.
- [버그 해결] Label 컴포넌트 `optional`, `require` props를 단일 `status`로 통합.
- [버그 해결] `CheckBox`의 `disable` 및 `error` 상태 중복 시 `error` 스타일 해제.

### 설명 (선택)

- **Storybook 업데이트**:
  - Next.js App Directory(`app/` 구조)를 지원하도록 Storybook 설정(예: `main.js`, `preview.js`) 업데이트.
  - 주간 작업 관련 컴포넌트(예: `Typography`, `CheckBox` 등)를 Storybook 스토리로 추가해 시각적 테스트 및 문서화.
  - Storybook에서 재사용 가능한 변수(예: props, 상수)를 `export`로 내보내고, 코드 문법을 최적화.

- **버그 수정**:
  -  Label 컴포넌트 `optional`과 `require` props를 `status` 속성으로 통합하여 휴먼 에러(예: 잘못된 props 설정) 방지.
  - `CheckBox` 컴포넌트에서 `disable`과 `error` 상태가 동시에 적용될 때, `error` 스타일이 우선 적용되지 않도록 수정.


- **목적**:
  - Storybook을 통해 컴포넌트 개발 및 테스트 환경 개선.
  - UI 컴포넌트의 일관성과 접근성을 높이고, 유지보수성 강화.

## 스크린샷
![스크린샷 2025-04-18 15 48 51](https://github.com/user-attachments/assets/f34d7c76-6c0f-4717-a060-bcf18d99f8c1)
![스크린샷 2025-04-18 15 51 18](https://github.com/user-attachments/assets/0b92954b-7c2e-4778-98e6-eb789a647900)
- 라벨 컴포넌트 props 업데이트 후 사용방법입니다!

## 리뷰 요구사항
- Storybook 스토리에서 `Typography` 및 `CheckBox`의 다양한 상태(예: `disabled`, `error`)가 충분히 문서화되었는지 검토 부탁드립니다!
- 라벨 컴포넌트 리뷰 부탁드립니다!