### PR TITLE
Feat[textBox]: 연관 컴포넌트 props 및 Search 컴포넌트 추가

### DIFF
--- a/src/components/common/Field/OptionGroup.tsx
+++ b/src/components/common/Field/OptionGroup.tsx
@@ -4,12 +4,14 @@ import { widthClassMap } from '@/components/common/Field/SelectField';
 import clsx from 'clsx';
 import React from 'react';
 
-type OptionGroupProps = {
+export type OptionGroupProps = {
   options: Option[]; // 렌더링할 옵션 리스트
   selectedValue: string; // 현재 선택된 값
   onClickHandler: (value: string) => void;
   type?: 'checkBox' | 'default';
   width?: 'default' | 'large' | 'small';
+  className?: string;
+  manualInputField?: string;
 };
 
 export const OptionGroup = ({
@@ -18,6 +20,8 @@ export const OptionGroup = ({
   onClickHandler,
   type = 'default',
   width = 'default',
+  manualInputField,
+  className,
 }: OptionGroupProps) => {
   return (
     <ul
@@ -25,6 +29,7 @@ export const OptionGroup = ({
       className={clsx(
         'flex flex-col mt-1 rounded border border-gray-30 bg-gray-0 p-space-2 focus:outline-none',
         widthClassMap[width],
+        className,
       )}
     >
       {type === 'checkBox' && (
@@ -41,6 +46,15 @@ export const OptionGroup = ({
           selectedValue={selectedValue}
           onClickHandler={onClickHandler}
           className="!w-full !justify-start"
+        />
+      )}
+      {manualInputField && (
+        <Label
+          focus
+          options={[{ value: manualInputField, label: `${manualInputField} 직접입력` }]}
+          selectedValue={selectedValue}
+          onClickHandler={onClickHandler}
+          className="!w-full !justify-center pt-2.5 cursor-pointer underline"
         />
       )}
     </ul>

--- a/src/components/common/Field/Search.tsx
+++ b/src/components/common/Field/Search.tsx
@@ -2,22 +2,15 @@
 
 import { Option } from '@/components/common/Field/Label';
 import { OptionGroup, OptionGroupProps } from '@/components/common/Field/OptionGroup';
-import TextBox, { TextBoxProps } from '@/components/common/Field/TextBox';
 import TextField, { TextFieldProps } from '@/components/common/Field/TextField';
-import Icon from '@/components/common/Icon/Icon';
 import { debounce } from '@/utils/debounce';
 import clsx from 'clsx';
 import React, { ChangeEvent, useMemo, useState } from 'react';
 
 export type SelectTextBoxProps = TextFieldProps & {
-  error?: boolean;
   optionGroupProps?: OptionGroupProps;
 };
-const Search = ({ error = false, optionGroupProps, ...props }: SelectTextBoxProps) => {
-  // error style 제거
-  if (props.disabled) {
-    error = false;
-  }
+const Search = ({ optionGroupProps, ...props }: SelectTextBoxProps) => {
   const [input, setInput] = useState('');
   const [isOpen, setIsOpen] = useState(false);
   const [filtered, setFiltered] = useState<Option[]>([]);
@@ -63,7 +56,7 @@ const Search = ({ error = false, optionGroupProps, ...props }: SelectTextBoxProp
     <div className="w-fit relative">
       <TextField
         {...props}
-        className={clsx(optionGroupProps && 'pr-[44px]')}
+        className={clsx(optionGroupProps && 'pr-11')}
         value={input}
         onChange={onChange}
         icon="search"

--- a/src/components/common/Field/Search.tsx
+++ b/src/components/common/Field/Search.tsx
@@ -2,17 +2,18 @@
 
 import { Option } from '@/components/common/Field/Label';
 import { OptionGroup, OptionGroupProps } from '@/components/common/Field/OptionGroup';
-import TextBox from '@/components/common/Field/TextBox';
+import TextBox, { TextBoxProps } from '@/components/common/Field/TextBox';
+import TextField, { TextFieldProps } from '@/components/common/Field/TextField';
 import Icon from '@/components/common/Icon/Icon';
 import { debounce } from '@/utils/debounce';
 import clsx from 'clsx';
-import React, { ChangeEvent, InputHTMLAttributes, useMemo, useState } from 'react';
+import React, { ChangeEvent, useMemo, useState } from 'react';
 
-export interface SelectTextBoxProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'className'> {
+export type SelectTextBoxProps = TextFieldProps & {
   error?: boolean;
   optionGroupProps?: OptionGroupProps;
-}
-const SelectTextBox = ({ error = false, optionGroupProps, ...props }: SelectTextBoxProps) => {
+};
+const Search = ({ error = false, optionGroupProps, ...props }: SelectTextBoxProps) => {
   // error style 제거
   if (props.disabled) {
     error = false;
@@ -60,14 +61,13 @@ const SelectTextBox = ({ error = false, optionGroupProps, ...props }: SelectText
 
   return (
     <div className="w-fit relative">
-      <TextBox
-        className={clsx(optionGroupProps && 'pr-space-32')}
-        error={error}
-        value={input}
+      <TextField
         {...props}
+        className={clsx(optionGroupProps && 'pr-[44px]')}
+        value={input}
         onChange={onChange}
+        icon="search"
       />
-      {optionGroupProps && <Icon className="absolute top-1/2 -translate-y-1/2 right-2" icon="search" size={24} />}
       {isOpen && optionGroupProps && (
         <OptionGroup
           {...optionGroupProps}
@@ -81,4 +81,4 @@ const SelectTextBox = ({ error = false, optionGroupProps, ...props }: SelectText
   );
 };
 
-export default SelectTextBox;
+export default Search;

--- a/src/components/common/Field/SelectTextBox.tsx
+++ b/src/components/common/Field/SelectTextBox.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { Option } from '@/components/common/Field/Label';
+import { OptionGroup, OptionGroupProps } from '@/components/common/Field/OptionGroup';
+import TextBox from '@/components/common/Field/TextBox';
+import Icon from '@/components/common/Icon/Icon';
+import { debounce } from '@/utils/debounce';
+import clsx from 'clsx';
+import React, { ChangeEvent, InputHTMLAttributes, useMemo, useState } from 'react';
+
+export interface SelectTextBoxProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'className'> {
+  error?: boolean;
+  optionGroupProps?: OptionGroupProps;
+}
+const SelectTextBox = ({ error = false, optionGroupProps, ...props }: SelectTextBoxProps) => {
+  // error style 제거
+  if (props.disabled) {
+    error = false;
+  }
+  const [input, setInput] = useState('');
+  const [isOpen, setIsOpen] = useState(false);
+  const [filtered, setFiltered] = useState<Option[]>([]);
+
+  const onSelect = (value: string) => {
+    const label = optionGroupProps?.options.find((o) => o.value === value)?.label;
+    setInput(label || value);
+    optionGroupProps?.onClickHandler(value);
+    setIsOpen(false);
+  };
+
+  const handleInput = useMemo(
+    () =>
+      debounce((event: ChangeEvent<HTMLInputElement>) => {
+        const { value } = event.target;
+        if (value.trim() !== '') {
+          const match = optionGroupProps?.options.filter((item) => item.label.includes(value)) || [];
+          setFiltered(match);
+          setIsOpen(true);
+        }
+      }, 300),
+    [],
+  );
+
+  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
+    if (e.target.value.trim() === '') {
+      setFiltered([]);
+      setIsOpen(false);
+      setInput('');
+      return;
+    }
+    if (props.onChange) {
+      props.onChange(e);
+    }
+    if (optionGroupProps) {
+      setInput(e.target.value);
+      optionGroupProps?.onClickHandler(''); // 선택 취소
+      handleInput(e);
+    }
+  };
+
+  return (
+    <div className="w-fit relative">
+      <TextBox
+        className={clsx(optionGroupProps && 'pr-space-32')}
+        error={error}
+        value={input}
+        {...props}
+        onChange={onChange}
+      />
+      {optionGroupProps && <Icon className="absolute top-1/2 -translate-y-1/2 right-2" icon="search" size={24} />}
+      {isOpen && optionGroupProps && (
+        <OptionGroup
+          {...optionGroupProps}
+          options={filtered}
+          onClickHandler={onSelect}
+          className="absolute -bottom-30 z-10 left-0"
+          manualInputField={input}
+        />
+      )}
+    </div>
+  );
+};
+
+export default SelectTextBox;

--- a/src/components/common/Field/TextBox.tsx
+++ b/src/components/common/Field/TextBox.tsx
@@ -41,7 +41,7 @@ const TextBox = ({ error = false, rounded = false, scale = 'base', icon, classNa
         placeholder="placeholder"
         {...props}
       />
-      {icon && <Icon className={clsx('absolute top-1/2 -translate-y-1/2 right-[16px]')} icon={icon} size={24} />}
+      {icon && <Icon className={clsx('absolute top-1/2 -translate-y-1/2 right-4')} icon={icon} size={24} />}
     </div>
   );
 };

--- a/src/components/common/Field/TextBox.tsx
+++ b/src/components/common/Field/TextBox.tsx
@@ -1,34 +1,48 @@
 'use client';
 
+import { IconType } from '@/components/common/Icon/assets';
+import Icon from '@/components/common/Icon/Icon';
 import clsx from 'clsx';
 import React, { InputHTMLAttributes } from 'react';
 
+const scaleStyleClass = {
+  base: 'h-space-48 px-[18px] py-[13px]',
+  sm: 'h-space-34 px-[18px] py-[7px]',
+};
 export interface TextBoxProps extends InputHTMLAttributes<HTMLInputElement> {
   error?: boolean;
+  rounded?: boolean;
   className?: string;
+  scale?: keyof typeof scaleStyleClass;
+  icon?: IconType;
 }
-const TextBox = ({ error = false, className, ...props }: TextBoxProps) => {
+
+const TextBox = ({ error = false, rounded = false, scale = 'base', icon, className, ...props }: TextBoxProps) => {
   // error style 제거
   if (props.disabled) {
     error = false;
   }
   return (
-    <input
-      type="text"
-      className={clsx(
-        `box-border w-60 h-space-48 rounded-md border px-space-12 py-space-8 text-gray-90
+    <div className="relative w-fit">
+      <input
+        type="text"
+        className={clsx(
+          `box-border w-60  rounded-md border text-gray-90
           border-interactive-secondary  
           hover:border-gray-50 hover:placeholder:text-gray-50
           active:border-gray-50 
           disabled:bg-disabled disabled:border-gray-40 disabled:placeholder:text-gray-50 disabled:cursor-not-allowed
           focus:outline-none
           text-[15px]`,
-        error && '!border-danger-border placeholder:!text-gray-90',
-        className,
-      )}
-      placeholder="placeholder"
-      {...props}
-    />
+          error && '!border-danger-border placeholder:!text-gray-90',
+          rounded && '!rounded-full',
+          scale && scaleStyleClass[scale],
+        )}
+        placeholder="placeholder"
+        {...props}
+      />
+      {icon && <Icon className={clsx('absolute top-1/2 -translate-y-1/2 right-[16px]')} icon={icon} size={24} />}
+    </div>
   );
 };
 

--- a/src/components/common/Field/TextBox.tsx
+++ b/src/components/common/Field/TextBox.tsx
@@ -1,51 +1,34 @@
 'use client';
 
-import { OptionGroup, OptionGroupProps } from '@/components/common/Field/OptionGroup';
-import Icon from '@/components/common/Icon/Icon';
-import { debounce } from '@/utils/debounce';
 import clsx from 'clsx';
-import React, { ChangeEvent, InputHTMLAttributes, useMemo } from 'react';
+import React, { InputHTMLAttributes } from 'react';
 
-export interface TextBoxProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'className'> {
+export interface TextBoxProps extends InputHTMLAttributes<HTMLInputElement> {
   error?: boolean;
-  optionGroupProps?: OptionGroupProps;
+  className?: string;
 }
-const TextBox = ({ error = false, optionGroupProps, onChange, ...props }: TextBoxProps) => {
+const TextBox = ({ error = false, className, ...props }: TextBoxProps) => {
   // error style 제거
   if (props.disabled) {
     error = false;
   }
-  const handleDebouncedChange = useMemo(
-    () =>
-      debounce((e: ChangeEvent<HTMLInputElement>) => {
-        if (onChange) onChange(e);
-      }, 1000),
-    [onChange],
-  );
   return (
-    <div className="w-fit relative">
-      <input
-        type="text"
-        className={clsx(
-          `box-border w-60 h-space-48 rounded-md border px-space-12 py-space-8 text-gray-90
+    <input
+      type="text"
+      className={clsx(
+        `box-border w-60 h-space-48 rounded-md border px-space-12 py-space-8 text-gray-90
           border-interactive-secondary  
           hover:border-gray-50 hover:placeholder:text-gray-50
           active:border-gray-50 
           disabled:bg-disabled disabled:border-gray-40 disabled:placeholder:text-gray-50 disabled:cursor-not-allowed
           focus:outline-none
           text-[15px]`,
-          optionGroupProps && 'pr-space-32',
-          error && '!border-danger-border placeholder:!text-gray-90',
-        )}
-        placeholder="placeholder"
-        {...props}
-        onChange={(event) => {
-          handleDebouncedChange(event);
-        }}
-      />
-      {optionGroupProps && <Icon className="absolute top-1/2 -translate-y-1/2 right-2" icon="search" size={24} />}
-      {optionGroupProps && <OptionGroup className="absolute -bottom-30 z-10 left-0" {...optionGroupProps} />}
-    </div>
+        error && '!border-danger-border placeholder:!text-gray-90',
+        className,
+      )}
+      placeholder="placeholder"
+      {...props}
+    />
   );
 };
 

--- a/src/components/common/Field/TextField.tsx
+++ b/src/components/common/Field/TextField.tsx
@@ -18,7 +18,7 @@ type WithoutLabel = {
 
 type WithOptionalLabel = WithLabel | WithoutLabel;
 
-type TextFieldProps = Omit<TextBoxProps, 'error'> &
+export type TextFieldProps = Omit<TextBoxProps, 'error'> &
   WithOptionalLabel & {
     helpMessage?: string;
     status: HelpMessageProps['status'];


### PR DESCRIPTION
## 유형

- [x] 기능 구현
- [ ] UI 구현
- [x] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용
- textBox Props 추가(scale, rounded, icon)
- Search 컴포넌트 추가(OptionGroup 컴포넌트와 합성)

## 설명

```tsx
'use client';
import Search from '@/components/common/Field/Search';
import TextBox from '@/components/common/Field/TextBox';
import TextField from '@/components/common/Field/TextField';

import { useState } from 'react';

const options = [
  { value: 'label1', label: '아주대학교' },
  { value: 'label2', label: '아주아주대학교' },
  { value: 'label3', label: '아주초등학교' },
  { value: 'label4', label: '아주중학교' },
];
export default function Home() {
  const [selected, setSelected] = useState(options[0].value);

  return (
    <div className="flex flex-col text-2xl gap-4">
      <Search
        label="asd"
        id="11"
        labelStatus="default"
        status="default"
        rounded
        optionGroupProps={{ selectedValue: selected, onClickHandler: setSelected, options: options }}
      />
      <TextField status="default" />
      <TextBox error rounded icon="human" />
      <TextBox disabled />
    </div>
  );
}

```

## 스크린샷
![스크린샷 2025-05-07 12 48 54](https://github.com/user-attachments/assets/398f656a-9e65-4e9f-906e-7c520dffccc4)



## 리뷰 요구사항
- Search 컴포넌트 구조 관련 피드백 및 오류있다면 말씀해주세요!
