### PR TITLE
Feat[modal]: Modal 컴포넌트 추가 및 Exit svg 에셋 추가

### DIFF
--- a/src/app/@modal/default-modal/page.tsx
+++ b/src/app/@modal/default-modal/page.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import Modal from '@/components/common/Modal/Modal';
+import useModal from '@/hooks/useModal';
+
+export default function Page() {
+  const { closeModal } = useModal();
+  return (
+    <Modal
+      isOpen={true}
+      onClose={closeModal}
+      onSuccess={() => console.log('success')}
+      title="title"
+      description="description"
+    />
+  );
+}

--- a/src/app/@modal/default.tsx
+++ b/src/app/@modal/default.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Default = () => {
+  return <></>;
+};
+
+export default Default;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,12 +9,17 @@ export const metadata: Metadata = {
 
 export default function RootLayout({
   children,
+  modal,
 }: Readonly<{
   children: React.ReactNode;
+  modal: React.ReactNode;
 }>) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        {children}
+        {modal}
+      </body>
     </html>
   );
 }

--- a/src/components/common/Button/Button.tsx
+++ b/src/components/common/Button/Button.tsx
@@ -104,6 +104,7 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   size: keyof typeof sizeStyleClass; // 버튼 사이즈
   buttonStyle: keyof typeof buttonStyleClass; // 버튼 스타일
   disabled?: boolean; // 비활성화 여부
+  className?: string;
   icon?: {
     // 아이콘 설정
     icon: IconProps['icon'];
@@ -113,7 +114,16 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 }
 
 // Button 컴포넌트 정의
-const Button = ({ label, disabled = false, icon, size, buttonStyle, isFullRounded = false, ...props }: ButtonProps) => {
+const Button = ({
+  label,
+  disabled = false,
+  icon,
+  size,
+  buttonStyle,
+  isFullRounded = false,
+  className,
+  ...props
+}: ButtonProps) => {
   // 아이콘 스타일 클래스 설정 (활성/비활성 상태에 따라 다름)
   const iconStyleClass = disabled
     ? buttonStyleClass[buttonStyle].disabled.textColor
@@ -128,6 +138,7 @@ const Button = ({ label, disabled = false, icon, size, buttonStyle, isFullRounde
         icon?.position === 'right' && sizeStyleClass[size].labelIconRight, // 아이콘이 오른쪽일 때 패딩 조정
         disabled ? buttonStyleClass[buttonStyle].disabled.label : buttonStyleClass[buttonStyle].active.label, // 상태별 스타일
         isFullRounded && '!rounded-full', // rounded 옵션이 true면 완전 둥근 버튼
+        className && className,
       )}
       {...props}
     >

--- a/src/components/common/Icon/assets/Exit.tsx
+++ b/src/components/common/Icon/assets/Exit.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+const Exit = ({ width, height, className, ...props }: React.SVGProps<SVGSVGElement>) => {
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox="0 0 15 15"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      {...props}
+    >
+      <path
+        d="M13.6172 1.44824L1.61719 13.4482M1.61719 1.44824L13.6172 13.4482"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+};
+
+export default Exit;

--- a/src/components/common/Icon/assets/index.ts
+++ b/src/components/common/Icon/assets/index.ts
@@ -23,6 +23,7 @@ import FillChevronDown from '@/components/common/Icon/assets/FillChevronDown';
 import FillChevronUp from '@/components/common/Icon/assets/FillChevronUp';
 import BookmarkLine from '@/components/common/Icon/assets/BookmarkLine';
 import BookmarkFill from '@/components/common/Icon/assets/BookmarkFill';
+import Exit from '@/components/common/Icon/assets/Exit';
 
 export const iconMap = {
   alertCircle: AlertCircle,
@@ -37,6 +38,7 @@ export const iconMap = {
   fillChevronUp: FillChevronUp,
   bookmarkLine: BookmarkLine,
   bookmarkFill: BookmarkFill,
+  exit: Exit,
 
   largeCheck: LargeCheck,
   largeAlertCircle: LargeAlertCircle,

--- a/src/components/common/Modal/Modal.tsx
+++ b/src/components/common/Modal/Modal.tsx
@@ -1,0 +1,91 @@
+// components/Modal.tsx
+'use client';
+
+import Button from '@/components/common/Button/Button';
+import Icon from '@/components/common/Icon/Icon';
+import Typography from '@/components/common/Typography';
+import React, { useEffect, useRef } from 'react';
+
+interface ModalProps {
+  isOpen: boolean;
+  title: string;
+  description: string;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+const Modal = ({ isOpen, onClose, onSuccess, title, description }: ModalProps) => {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  // ESC 키로 닫기
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    if (isOpen) window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [isOpen, onClose]);
+
+  // 포커스 트랩
+  useEffect(() => {
+    if (isOpen && closeButtonRef.current) {
+      closeButtonRef.current.focus();
+    }
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const onSuccessHandler = () => {
+    onSuccess();
+    onClose();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-10 flex items-center justify-center bg-gray-100/40"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="modal-title"
+      aria-describedby="modal-description"
+    >
+      <div
+        ref={dialogRef}
+        className="flex flex-col w-[360px] bg-gray-0 rounded-2xl px-space-32 pt-[22px] pb-[28px] gap-space-12 "
+        tabIndex={-1}
+      >
+        {/* Header */}
+        <div className="flex justify-end">
+          <button
+            ref={closeButtonRef}
+            onClick={onClose}
+            aria-label="닫기"
+            className="flex justify-center items-center size-6"
+          >
+            <Icon icon="exit" size={12} className="text-gray-90" />
+          </button>
+        </div>
+
+        <div className="flex flex-col gap-space-32">
+          {/* Body */}
+          <div className="flex flex-col items-center justify-center gap-2">
+            <Typography tag="h1" type="Heading1Semibold" id="modal-title" className="text-gray-90">
+              {title}
+            </Typography>
+            <Typography tag="p" type="Body4Regular" id="modal-description" className="text-gray-50">
+              {description}
+            </Typography>
+          </div>
+
+          {/* Footer */}
+          <div className="mt-6 flex gap-2">
+            <Button className="w-full" buttonStyle="filled" size="base" label="취소" onClick={onClose} />
+
+            <Button className="w-full" buttonStyle="outlined" size="base" label="확인" onClick={onSuccessHandler} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+export default Modal;

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -1,0 +1,16 @@
+import { useRouter } from 'next/navigation';
+
+const useModal = () => {
+  const router = useRouter();
+
+  const openDefaultModal = () => {
+    router.push('/default-modal');
+  };
+
+  const closeModal = () => {
+    router.back();
+  };
+  return { openDefaultModal, closeModal };
+};
+
+export default useModal;


### PR DESCRIPTION
## 유형

- [x] 기능 구현
- [x] UI 구현
- [ ] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용
- Modal UI 구현
- Exit svg 에셋 추가
- /@modal 계층 생성

### 설명
```tsx
'use client';
import Button from '@/components/common/Button/Button';
import useModal from '@/hooks/useModal';

export default function Home() {
  const { openDefaultModal } = useModal();

  return (
    <div className="flex">
      <Button label="button" size="base" buttonStyle="filled" onClick={openDefaultModal} />
    </div>
  );
}

```

상세한 설명

## 스크린샷
![스크린샷 2025-05-07 14 13 10](https://github.com/user-attachments/assets/ce11a8aa-dad2-4aea-991c-5c65061a8621)

## 리뷰 요구사항
- 접근성 및 구현 구조에 대해 피드백 가능하시면 해주세요!
- 뒤로가기 동작에 대한 논의도 필요할 것 같습니다!
