### PR TITLE
Fix[iconButton]: Divider 컴포넌트 추가 및 IconButton 수정사항 반영 

### DIFF
--- a/src/components/Divider/Divider.tsx
+++ b/src/components/Divider/Divider.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import clsx from 'clsx';
+
+interface DividerProps extends React.HTMLAttributes<HTMLDivElement> {
+  vertical?: boolean;
+  className?: string;
+}
+
+export const Divider = ({ vertical = false, className, ...props }: DividerProps) => {
+  return (
+    <div
+      role="separator"
+      aria-orientation={vertical ? 'vertical' : 'horizontal'}
+      className={clsx('bg-gray-20', vertical ? 'h-space-32 w-[1px]' : 'w-[375px] h-[1px]', className)}
+      {...props}
+    />
+  );
+};

--- a/src/components/common/Button/IconButton.tsx
+++ b/src/components/common/Button/IconButton.tsx
@@ -32,15 +32,29 @@ const iconStyleClass = {
   standard: { active: 'text-gray-90 group-active:text-gray-50', readonly: 'text-gray-90', disabled: 'text-gray-40' },
 };
 
+const sizeStyleClass = {
+  base: {
+    box: 'size-space-48',
+    wrapper: 'size-space-40 ',
+    iconSize: 24,
+  },
+  sm: {
+    box: 'size-9',
+    wrapper: 'size-7 ',
+    iconSize: 20,
+  },
+};
+
 // IconButton 컴포넌트 props 타입 정의
 interface IconButtonProps extends DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> {
   buttonStyles: keyof typeof styleClass; // 버튼 스타일 타입 (filled | outlined | standard)
+  size?: keyof typeof sizeStyleClass;
   icon: IconProps['icon'];
   readonly?: boolean;
 }
 
 // IconButton 컴포넌트 정의
-const IconButton = ({ buttonStyles, icon, disabled, readonly = false, ...props }: IconButtonProps) => {
+const IconButton = ({ buttonStyles, icon, disabled, size = 'base', readonly = false, ...props }: IconButtonProps) => {
   const getStyleClass = (type: 'button' | 'icon') => {
     const style = type === 'button' ? styleClass[buttonStyles] : iconStyleClass[buttonStyles];
     if (disabled) {
@@ -55,7 +69,8 @@ const IconButton = ({ buttonStyles, icon, disabled, readonly = false, ...props }
       type={props.type || 'button'}
       aria-disabled={disabled || readonly} // 비활성화 또는 읽기 전용 상태일 때 속성 추가
       className={clsx(
-        'group flex items-center justify-center size-space-48 rounded-full', // 기본 스타일
+        'group flex items-center justify-center rounded-full', // 기본 스타일
+        sizeStyleClass[size].box,
         readonly && 'cursor-default',
         disabled && 'cursor-not-allowed', // 비활성화 시 커서 스타일 변경
       )}
@@ -63,12 +78,13 @@ const IconButton = ({ buttonStyles, icon, disabled, readonly = false, ...props }
     >
       <div
         className={clsx(
-          'flex items-center justify-center size-space-40 rounded-full', // 버튼 안쪽 스타일
+          'flex items-center justify-center  rounded-full', // 버튼 안쪽 스타일
+          sizeStyleClass[size].wrapper,
           getStyleClass('button'),
         )}
       >
         {/* 아이콘 렌더링 */}
-        <Icon icon={icon} size={24} className={clsx(getStyleClass('icon'))} />
+        <Icon icon={icon} size={sizeStyleClass[size].iconSize} className={clsx(getStyleClass('icon'))} />
       </div>
     </button>
   );

--- a/src/components/common/Funnel/FunnelStep.tsx
+++ b/src/components/common/Funnel/FunnelStep.tsx
@@ -22,11 +22,9 @@ const FunnelStep = ({
   showLine: boolean;
 }) => {
   return (
-    <div className="flex flex-col items-center justify-between w-[48px] h-[52px] transition-all">
+    <div className="flex flex-col items-center justify-between w-12 h-[52px] transition-all">
       <div className="relative flex items-center justify-center size-9">
-        {showLine && (
-          <Divider className="absolute top-1/2 left-full -translate-x-[4px] -translate-y-1/2 -z-10 !w-[45px]" />
-        )}
+        {showLine && <Divider className="absolute top-1/2 left-full -translate-x-1 -translate-y-1/2 -z-10 !w-[45px]" />}
         <IconButton
           size="sm"
           aria-current={isActive ? 'step' : undefined}

--- a/src/components/common/Funnel/FunnelStep.tsx
+++ b/src/components/common/Funnel/FunnelStep.tsx
@@ -1,6 +1,7 @@
 import IconButton from '@/components/common/Button/IconButton';
 import { IconProps } from '@/components/common/Icon/Icon';
 import Typography from '@/components/common/Typography';
+import { Divider } from '@/components/Divider/Divider';
 import clsx from 'clsx';
 import React from 'react';
 
@@ -21,22 +22,25 @@ const FunnelStep = ({
   showLine: boolean;
 }) => {
   return (
-    <div className="flex flex-col items-center justify-between w-[60px] transition-all">
-      <div className="relative flex items-center justify-center w-space-40 h-space-40">
-        {showLine && <div className="absolute top-1/2 left-full w-[44px] h-px bg-gray-30 -translate-y-1/2 -z-10" />}
+    <div className="flex flex-col items-center justify-between w-[48px] h-[52px] transition-all">
+      <div className="relative flex items-center justify-center size-9">
+        {showLine && (
+          <Divider className="absolute top-1/2 left-full -translate-x-[4px] -translate-y-1/2 -z-10 !w-[45px]" />
+        )}
         <IconButton
+          size="sm"
           aria-current={isActive ? 'step' : undefined}
-          buttonStyles={isActive || isPast ? 'filled' : 'outlined'}
+          buttonStyles={isActive ? 'filled' : 'outlined'}
           disabled={isPast || !isActive}
           readonly
           icon={step.icon}
         />
       </div>
       <Typography
-        type="Body2Medium"
+        type={isActive ? 'Caption2Medium' : 'Caption2Regular'}
         className={clsx({
-          'text-gray-90': isActive,
-          'text-gray-30': !isActive,
+          'text-gray-60': isActive,
+          'text-gray-40': !isActive,
         })}
       >
         {step.label}


### PR DESCRIPTION
## 유형

- [x] 기능 구현
- [x] UI 구현
- [ ] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용
```tsx
'use client';

import { Divider } from '@/components/Divider/Divider';

export default function Home() {
  return (
    <div className="flex ml-2 mt-2">
      <Divider vertical />
      <Divider />
    </div>
  );
}

```
- Divider 예시입니다!

### 설명 
- Divider는 원래 따로 제작하려고 했는데 signUpFunnel에 divider로 제작되어 있어서 추가했습니다!

## 스크린샷
![스크린샷 2025-05-07 15 18 51](https://github.com/user-attachments/assets/96aaf340-e494-4e5b-8bf8-e8e45b9e7ce5)
![스크린샷 2025-05-07 15 19 01](https://github.com/user-attachments/assets/8c1db93d-25dc-4b6d-abe1-47477dd486da)

## 리뷰 요구사항
- 디자인 반영이 잘 되었는지 크로스 체크 한번 부탁드립니다!
