### PR TITLE
Fix[mo-schedule-list]: 디자인과 다르게 폰트 사이즈 width가 먹히지 않아 유동적으로 적용되기 위해 수정

### DIFF
--- a/src/components/common/Calendar/Chip.tsx
+++ b/src/components/common/Calendar/Chip.tsx
@@ -3,28 +3,32 @@ import clsx from 'clsx';
 import React from 'react';
 
 interface ChipProps extends React.HTMLAttributes<HTMLDivElement> {
-    text: string;
-    period: "start" | "deadline";
+  text: string;
+  period: 'start' | 'deadline';
 }
 
 const chipStyle = {
-    start: {
-        bg: "bg-primary-10",
-        text: "text-primary-60",
-    },
-    deadline: {
-        bg: "bg-danger-5",
-        text: "text-danger-40",
-    },
-}
+  start: {
+    bg: 'bg-primary-10',
+    text: 'text-primary-60',
+  },
+  deadline: {
+    bg: 'bg-danger-5',
+    text: 'text-danger-40',
+  },
+};
 
-const Chip = ({ text, className, period = "start", ...props }: ChipProps) => {
-    
-    return (
-        <div className={clsx("flex w-[33px] h-5 items-center px-1.5 py-.5 rounded",chipStyle[period].bg, className)} {...props}>
-            <Typography type="Caption1Semibold" className={chipStyle[period].text}>{text}</Typography>
-        </div>
-    );
+const Chip = ({ text, className, period = 'start', ...props }: ChipProps) => {
+  return (
+    <div
+      className={clsx('flex w-[33px] h-[22px] items-center justify-center rounded', chipStyle[period].bg, className)}
+      {...props}
+    >
+      <Typography type="Caption1Semibold" className={chipStyle[period].text}>
+        {text}
+      </Typography>
+    </div>
+  );
 };
 
 export default Chip;

--- a/src/components/common/List/mobile/MoScheduleList.tsx
+++ b/src/components/common/List/mobile/MoScheduleList.tsx
@@ -51,7 +51,7 @@ const MoScheduleList: React.FC<MoScheduleListProps> = ({ schedule, onApply, onBo
   };
 
   return (
-    <div className={`flex flex-col w-[375px] h-[164px] rounded-[10px] p-5 pt-[18px] border gap-3 ${className}`}>
+    <div className={`flex flex-col w-[375px] rounded-[10px] px-5 py-[18px] border gap-3 ${className}`}>
       <div className="flex justify-between h-6 flex-1">
         <div className="flex gap-2.5">
           <Chip text={schedule.period === 'start' ? '시작' : '마감'} period={schedule.period} />
@@ -68,14 +68,16 @@ const MoScheduleList: React.FC<MoScheduleListProps> = ({ schedule, onApply, onBo
           />
         </div>
       </div>
-      <div className="flex flex-col gap-2 py-[3px] flex-2">
-        <Typography type="Body2Semibold">{schedule.title}</Typography>
+      <div className="flex flex-col gap-1 py-[3px] flex-2">
+        <Typography type="Body2Semibold" className="overflow-hidden text-ellipsis whitespace-nowrap">
+          {schedule.title}
+        </Typography>
         <Typography type="Caption2Medium" className="text-gray-50">
           {schedule.companyName}
         </Typography>
       </div>
-      <div className="flex justify-between gap-2">
-        <div className="flex flex-col gap-2 flex-1">
+      <div className="flex">
+        <div className="flex flex-col gap-1 flex-1">
           <Typography type="Caption2Regular" className="text-gray-50">
             지원기간
           </Typography>


### PR DESCRIPTION
## 유형

- [ ] 기능 구현
- [ ] UI 구현
- [x] 리팩토링
- [x] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용
- 디자인과 다르게 폰트 사이즈 width가 먹히지 않아 유동적으로 적용되기 위해 수정
- figma와 다르게 스타일이 적용되어 있어서 수정

### 설명 (선택)

상세한 설명

## 스크린샷
<img width="645" height="585" alt="image" src="https://github.com/user-attachments/assets/6f19cd04-a477-4c00-a335-4d642976e3fa" />

피그마 기준 21px이 되어있지만 동일한 스타일을 적용시켰을 때, 실제 입히는 텍스트 width는 22.08px로 나와있었습니다. 
그래서, padding을 입히면 텍스트가 깨져 위아래로 적용이 되어있어
기존 `px-1.5` ->  `justify-center`로 텍스트가 가운데 위치할 수 있게 수정했습니다.

## 리뷰 요구사항
- 여기서 궁금한건 px-1.5(피그마 기준)를 유지하되, `break-keep`을 사용하는 방법도 생각하긴 했었는데 `justify-center`가 좀 더 자연스러운 느낌이 나긴 했는데 어떻게 생각하시나요?!!
- 또한 텍스트 width가 21px로 나와야 정상이지만 22.08px로 나오기 때문에 해결할 방법이 있는지 고민하고 있습니다!
