### PR TITLE
Fix[pc-gnb-style]: gap-9 -> gap-7 디자인에 맞게 반영

### DIFF
--- a/src/components/common/GNB/pc/GNB.tsx
+++ b/src/components/common/GNB/pc/GNB.tsx
@@ -37,7 +37,7 @@ const GNB = ({ isLogin = false }: GNBProps) => {
             <Image src="/imgs/logo.png" width={93} height={22} alt="PickLab 로고" />
           </Link>
           <nav aria-label="메인 메뉴">
-            <ul className="flex gap-9">
+            <ul className="flex gap-7">
               {GNBNavigationMenus.map((menu) => (
                 <li key={menu.label}>
                   <GNBMenu href={menu.href}>{menu.label}</GNBMenu>


### PR DESCRIPTION
## 유형

- [ ] 기능 구현
- [ ] UI 구현
- [x] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용
- GNB 메뉴 ul gap 36px(gap-9) -> 28px(gap-7) 변경

## 스크린샷

<img width="1273" height="591" alt="image" src="https://github.com/user-attachments/assets/d893b3a5-2f90-40aa-95de-52025a174475" />

## 리뷰 요구사항
-
