### PR TITLE
Feat[home]: Home 퍼블리싱

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "react": "^18",
         "react-dom": "^18",
         "react-hook-form": "^7.54.2",
+        "swiper": "^11.2.10",
         "tailwind-merge": "^3.3.1",
         "zod": "^3.24.2",
         "zustand": "^5.0.3"
@@ -12915,6 +12916,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swiper": {
+      "version": "11.2.10",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.2.10.tgz",
+      "integrity": "sha512-RMeVUUjTQH+6N3ckimK93oxz6Sn5la4aDlgPzB+rBrG/smPdCTicXyhxa+woIpopz+jewEloiEE3lKo1h9w2YQ==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/swiperjs"
+        },
+        {
+          "type": "open_collective",
+          "url": "http://opencollective.com/swiper"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.7.0"
       }
     },
     "node_modules/tailwind-merge": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.54.2",
+    "swiper": "^11.2.10",
     "tailwind-merge": "^3.3.1",
     "zod": "^3.24.2",
     "zustand": "^5.0.3"

--- a/src/app/(home)/_components/Banner.tsx
+++ b/src/app/(home)/_components/Banner.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { Pagination, Autoplay } from 'swiper/modules';
+import Image from 'next/image';
+
+import 'swiper/css';
+import 'swiper/css/pagination';
+
+// 배너 데이터
+const BANNER_MOCK = [
+  {
+    id: 1,
+    image: '/imgs/placeholder_mo_list.png',
+  },
+  {
+    id: 2,
+    image: '/imgs/ThreeDImagePlaceHolder.jpg',
+  },
+  {
+    id: 3,
+    image: '/imgs/cat.jpg',
+  },
+];
+
+export default function Banner() {
+  return (
+    <div className="mobile:w-full mobile:h-[200px] pc:w-full pc:h-[400px] relative">
+      <Swiper
+        modules={[Pagination, Autoplay]}
+        spaceBetween={0}
+        slidesPerView={1}
+        pagination={{
+          clickable: true,
+          bulletClass: 'swiper-pagination-bullet !bg-white !opacity-50',
+          bulletActiveClass: 'swiper-pagination-bullet-active !bg-white !opacity-100',
+        }}
+        autoplay={{
+          delay: 3000,
+          disableOnInteraction: false,
+        }}
+        loop={true}
+        className="w-full h-full rounded-lg overflow-hidden"
+      >
+        {BANNER_MOCK.map((banner) => (
+          <SwiperSlide key={banner.id}>
+            <div className="relative w-full h-full">
+              <Image src={banner.image} alt={banner.image} fill className="object-cover" priority={banner.id === 1} />
+            </div>
+          </SwiperSlide>
+        ))}
+      </Swiper>
+
+      {/* 커스텀 스타일 */}
+      <style jsx global>{`
+        .swiper-button-prev,
+        .swiper-button-next {
+          background: rgba(0, 0, 0, 0.3);
+          border-radius: 50%;
+          transition: background 0.3s ease;
+        }
+        .swiper-button-prev:hover,
+        .swiper-button-next:hover {
+          background: rgba(0, 0, 0, 0.5);
+        }
+        .swiper-pagination {
+          bottom: 20px !important;
+        }
+        .swiper-pagination-bullet {
+          width: 8px !important;
+          height: 8px !important;
+          margin: 0 4px !important;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/src/app/(home)/_components/mobile/ActivityList.tsx
+++ b/src/app/(home)/_components/mobile/ActivityList.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import Typography from '@/components/common/Typography';
+import Card from '@/components/common/Card/mobile/Card';
+import MoList from '@/components/common/List/mobile/MoList';
+import clsx from 'clsx';
+
+import Select from '@/components/common/Select/Select';
+
+interface ActivityListProps {
+  title: string;
+  type?: 'card' | 'list';
+  className?: string;
+  isSelect?: boolean;
+}
+
+export default function ActivityList({ title, type = 'card', className, isSelect }: ActivityListProps) {
+  return (
+    <div className={clsx('w-full flex flex-col gap-3', className)}>
+      <Typography type="Headline1SemiBold">{title}</Typography>
+      {isSelect && (
+        <div className="flex gap-2">
+          <Select
+            size="xsmall"
+            width="xsmall"
+            type="checkbox"
+            functionOptionType="reset"
+            className="!rounded-full !w-[98px] !h-[34px]"
+            options={[
+              { label: '대외활동', value: 'external_activity' },
+              { label: '강연/세미나', value: 'seminar' },
+              { label: '교육', value: 'education' },
+              { label: '공모전/해커톤', value: 'contest' },
+            ]}
+            onChange={() => {}}
+          />
+          <Select
+            size="small"
+            width="small"
+            type="checkbox"
+            functionOptionType="reset"
+            className="!rounded-full !w-[98px] !h-[34px]"
+            options={[
+              { label: '기획', value: 'planning' },
+              { label: '디자인', value: 'design' },
+              { label: '개발', value: 'development' },
+              { label: '마케팅', value: 'marketing' },
+              { label: 'AI', value: 'ai' },
+            ]}
+            onChange={() => {}}
+          />
+        </div>
+      )}
+
+      <div
+        className={clsx('flex overflow-x-scroll hide-scrollbar w-full', type === 'card' ? 'gap-4' : 'flex-col gap-2')}
+      >
+        {Array.from({ length: type === 'card' ? 10 : 3 }).map((_, index) =>
+          type === 'card' ? (
+            <Card
+              key={index}
+              imageUrl={'/imgs/cat.jpg'}
+              chipText="공모전/해커톤"
+              badgeText="D-01"
+              badgeVariant="default"
+              isBookmarked={false}
+              companyName="삼양 그룹"
+              title="2025 삼양그룹 대학생 서포터즈 Samyang Seeds 9기"
+              jobs={['개발']}
+              onBookmarkClick={() => {}}
+              onCardClick={() => {}}
+            />
+          ) : (
+            <MoList
+              key={index}
+              imageSrc={'/imgs/cat.jpg'}
+              company="삼양 그룹"
+              title="2025 삼양그룹 대학생 서포터즈 Samyang Seeds 9기"
+              viewCount={10}
+              saveCount={10}
+              isBookmarked={false}
+              onListClick={() => {}}
+              onBookmarkClick={() => {}}
+            />
+          ),
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(home)/_components/pc/ActivityList.tsx
+++ b/src/app/(home)/_components/pc/ActivityList.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useRef } from 'react';
+import Card from '@/components/common/Card/Card';
+import ChevronLeft from '@/components/common/Icon/assets/ChevronLeft';
+import ChevronRight from '@/components/common/Icon/assets/ChevronRight';
+import Typography from '@/components/common/Typography';
+import ListItem from '@/components/common/List/ListItem';
+
+interface ActivityListProps {
+  title: string;
+  type?: 'card' | 'list';
+}
+
+export default function ActivityList({ title, type = 'card' }: ActivityListProps) {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+  const scrollLeft = () => {
+    if (scrollContainerRef.current) {
+      scrollContainerRef.current.scrollBy({
+        left: -300, // 한 번에 스크롤할 거리 (px)
+        behavior: 'smooth',
+      });
+    }
+  };
+
+  const scrollRight = () => {
+    if (scrollContainerRef.current) {
+      scrollContainerRef.current.scrollBy({
+        left: 300, // 한 번에 스크롤할 거리 (px)
+        behavior: 'smooth',
+      });
+    }
+  };
+
+  return (
+    <div className="w-full flex flex-col gap-3">
+      <div className="flex justify-between items-center py-[1px]">
+        <Typography type="Heading1Bold">{title}</Typography>
+        <div className="flex gap-2">
+          <ChevronIconButton direction="left" onClick={scrollLeft} />
+          <ChevronIconButton direction="right" onClick={scrollRight} />
+        </div>
+      </div>
+      <div ref={scrollContainerRef} className="flex gap-5 overflow-x-scroll hide-scrollbar w-full">
+        {Array.from({ length: 10 }).map((_, index) =>
+          type === 'card' ? (
+            <Card
+              key={index}
+              imageUrl={'/imgs/cat.jpg'}
+              chipText="공모전/해커톤"
+              badgeText="D-01"
+              badgeVariant="default"
+              isBookmarked={false}
+              companyName="삼양 그룹"
+              title="2025 삼양그룹 대학생 서포터즈 Samyang Seeds 9기"
+              jobs={['개발']}
+              onBookmarkClick={() => {}}
+              onCardClick={() => {}}
+            />
+          ) : (
+            <ListItem
+              key={index}
+              thumbnail={'/imgs/cat.jpg'}
+              title="2025 삼양그룹 대학생 서포터즈 Samyang Seeds 9기"
+              label="진행중"
+              chipTitle="공모전/해커톤"
+              organization="삼양 그룹"
+              startDate={new Date('2025-05-01')}
+              endDate={new Date('2025-05-15')}
+              isFinished={false}
+              onListClick={() => {}}
+              onBookmarkClick={() => {}}
+              saveCount={10}
+              viewCount={100}
+            />
+          ),
+        )}
+      </div>
+    </div>
+  );
+}
+
+const ChevronIconButton = ({ direction, onClick }: { direction: 'left' | 'right'; onClick: () => void }) => {
+  return (
+    <button
+      onClick={onClick}
+      className="w-8 h-8 rounded-[4px] border-gray-20 border flex items-center justify-center hover:bg-gray-50 transition-colors"
+    >
+      {direction === 'left' ? (
+        <ChevronLeft color="#101828" height={13.5} />
+      ) : (
+        <ChevronRight color="#101828" height={13.5} />
+      )}
+    </button>
+  );
+};

--- a/src/app/(home)/_components/pc/NewActivityList.tsx
+++ b/src/app/(home)/_components/pc/NewActivityList.tsx
@@ -1,0 +1,77 @@
+'use client';
+import Card from '@/components/common/Card/Card';
+import Typography from '@/components/common/Typography';
+import SortTab from '@/components/common/Tab/SortTab';
+import Select from '@/components/common/Select/Select';
+
+interface NewActivityListProps {
+  title: string;
+}
+
+export default function NewActivityList({ title }: NewActivityListProps) {
+  return (
+    <div className="w-full flex flex-col gap-3">
+      <div className="flex flex-col gap-4">
+        <Typography type="Heading1Bold">{title}</Typography>
+
+        <div className="flex items-end justify-between w-full">
+          <div className="flex gap-2">
+            <Select
+              size="small"
+              width="small"
+              type="checkbox"
+              functionOptionType="reset"
+              className="!rounded-full"
+              options={[
+                { label: '대외활동', value: 'external_activity' },
+                { label: '강연/세미나', value: 'seminar' },
+                { label: '교육', value: 'education' },
+                { label: '공모전/해커톤', value: 'contest' },
+              ]}
+              onChange={() => {}}
+            />
+            <Select
+              size="small"
+              width="small"
+              type="checkbox"
+              functionOptionType="reset"
+              className="!rounded-full"
+              options={[
+                { label: '기획', value: 'planning' },
+                { label: '디자인', value: 'design' },
+                { label: '개발', value: 'development' },
+                { label: '마케팅', value: 'marketing' },
+                { label: 'AI', value: 'ai' },
+              ]}
+              onChange={() => {}}
+            />
+          </div>
+          <SortTab
+            options={[
+              { label: '최신순', value: 'latest' },
+              { label: '마감임박순', value: 'soon' },
+              { label: '여유 있는순', value: 'remain' },
+            ]}
+          />
+        </div>
+      </div>
+      <div className="grid grid-cols-4 gap-5">
+        {Array.from({ length: 10 }).map((_, index) => (
+          <Card
+            key={index}
+            imageUrl={'/imgs/cat.jpg'}
+            chipText="공모전/해커톤"
+            badgeText="D-01"
+            badgeVariant="default"
+            isBookmarked={false}
+            companyName="삼양 그룹"
+            title="2025 삼양그룹 대학생 서포터즈 Samyang Seeds 9기"
+            jobs={['개발']}
+            onBookmarkClick={() => {}}
+            onCardClick={() => {}}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(home)/layout.tsx
+++ b/src/app/(home)/layout.tsx
@@ -1,0 +1,11 @@
+import Footer from '@/components/common/Footer/Footer';
+
+export default function HomeLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen">
+      {/* Main Content */}
+      <main className="mx-auto pc:max-w-[1100px] mobile:max-w-[335px] mb-10">{children}</main>
+      <Footer className="mobile:hidden" />
+    </div>
+  );
+}

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -1,0 +1,74 @@
+import Banner from './_components/Banner';
+import PcActivityList from './_components/pc/ActivityList';
+import NewActivityList from './_components/pc/NewActivityList';
+import Pagination from '@/components/common/Pagination/Pagination';
+import clsx from 'clsx';
+import MobileActivityList from './_components/mobile/ActivityList';
+
+// 상수 정의
+const ACTIVITY_TITLES = {
+  RECOMMENDED: '00 직무를 위한 추천 활동',
+  POPULAR: '이번주 인기 대외활동',
+  RECENT: '최근에 본 활동',
+  NEW: '방금 올라온 따끈따끈한 활동!',
+} as const;
+
+const PAGINATION_CONFIG = {
+  TOTAL_PAGE: 10,
+  ACTIVE_PAGE: 1,
+} as const;
+
+// 스타일 상수
+const MOBILE_STYLES = {
+  CONTAINER: 'flex flex-col pb-[113px]',
+  FIRST_SECTION: 'mt-5',
+  SECOND_SECTION: 'mt-10',
+  THIRD_SECTION: 'mt-[60px]',
+} as const;
+
+const PC_STYLES = {
+  CONTAINER: 'flex flex-col gap-10 px-5 pb-20',
+  CONTENT_WRAPPER: 'flex flex-col items-center justify-center gap-[60px]',
+  HIDDEN_ON_MOBILE: 'mobile:hidden',
+  HIDDEN_ON_PC: 'pc:hidden',
+} as const;
+
+// 타입 정의
+interface ResponsiveLayoutProps {
+  className: string;
+}
+
+export default function Home() {
+  return (
+    <>
+      <MobileLayout className={PC_STYLES.HIDDEN_ON_PC} />
+      <PcLayout className={PC_STYLES.HIDDEN_ON_MOBILE} />
+    </>
+  );
+}
+
+function MobileLayout({ className }: ResponsiveLayoutProps) {
+  return (
+    <div className={clsx(MOBILE_STYLES.CONTAINER, className)}>
+      <Banner />
+      <MobileActivityList title={ACTIVITY_TITLES.RECOMMENDED} className={MOBILE_STYLES.FIRST_SECTION} />
+      <MobileActivityList title={ACTIVITY_TITLES.POPULAR} type="list" className={MOBILE_STYLES.SECOND_SECTION} />
+      <MobileActivityList title={ACTIVITY_TITLES.NEW} className={MOBILE_STYLES.THIRD_SECTION} isSelect />
+    </div>
+  );
+}
+
+function PcLayout({ className }: ResponsiveLayoutProps) {
+  return (
+    <div className={clsx(PC_STYLES.CONTAINER, className)}>
+      <div className={PC_STYLES.CONTENT_WRAPPER}>
+        <Banner />
+        <PcActivityList title={ACTIVITY_TITLES.RECOMMENDED} />
+        <PcActivityList title={ACTIVITY_TITLES.POPULAR} type="list" />
+        <PcActivityList title={ACTIVITY_TITLES.RECENT} />
+        <NewActivityList title={ACTIVITY_TITLES.NEW} />
+      </div>
+      <Pagination totalPage={PAGINATION_CONFIG.TOTAL_PAGE} activePage={PAGINATION_CONFIG.ACTIVE_PAGE} />
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -48,3 +48,13 @@ body {
 ::-webkit-scrollbar-thumb:hover {
   background-color: #d1d5dc;
 }
+
+/* 스크롤바 숨김 유틸리티 클래스 */
+.hide-scrollbar {
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none; /* IE and Edge */
+}
+
+.hide-scrollbar::-webkit-scrollbar {
+  display: none; /* Chrome, Safari, Opera */
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,0 @@
-export default function Home() {
-  return <div className="text-2xl">hello</div>;
-}

--- a/src/components/common/Card/Card.tsx
+++ b/src/components/common/Card/Card.tsx
@@ -38,7 +38,7 @@ const Card = ({
     <div
       onClick={onCardClick}
       aria-label={`카드: ${title}`}
-      className="flex flex-col w-[250px] h-[358px] rounded-[10px] bg-white cursor-pointer"
+      className="flex flex-col min-w-[250px] h-[358px] rounded-[10px] bg-white cursor-pointer"
     >
       {/* 이미지 영역 */}
       <div className="relative w-full h-[180px] overflow-hidden">

--- a/src/components/common/Card/mobile/Card.tsx
+++ b/src/components/common/Card/mobile/Card.tsx
@@ -35,7 +35,7 @@ const Card = ({
     <div
       onClick={onCardClick}
       aria-label={`카드: ${title}`}
-      className="flex flex-col w-[158px] h-[301px] rounded-[10px] bg-white cursor-pointer"
+      className="flex flex-col min-w-[158px] h-[301px] rounded-[10px] bg-white cursor-pointer"
     >
       {/* 이미지 영역 */}
       <div className="relative w-full h-40 overflow-hidden">

--- a/src/components/common/Footer/Footer.tsx
+++ b/src/components/common/Footer/Footer.tsx
@@ -1,22 +1,28 @@
 import FooterMenuGroup from '@/components/common/Footer/FooterMenuGroup';
 import Typography from '@/components/common/Typography';
 import { FOOTER_MENUS } from '@/constants/menus';
+import clsx from 'clsx';
 import Image from 'next/image';
 import Link from 'next/link';
 import React from 'react';
 
-const Footer = () => {
+const Footer = ({ className }: { className: string }) => {
   const firstColMenus = FOOTER_MENUS.slice(0, 2);
   const secondColMenus = FOOTER_MENUS.slice(2, 4);
   const thirdColMenus = FOOTER_MENUS.slice(4, 5);
 
   return (
-    <footer className="w-full max-w-[1440px] mx-auto pt-[23px] pb-[53px] flex flex-col items-center gap-[64px]">
+    <footer
+      className={clsx(
+        'w-full max-w-[1440px] mx-auto pt-[23px] pb-[53px] flex flex-col items-center gap-[64px]',
+        className,
+      )}
+    >
       <div className="w-[1040px] flex justify-between items-start">
         {/* Logo + Navigation */}
         <div className="flex gap-[70px]">
           <Link href="/" aria-label="홈으로 가기">
-            <Image src="/imgs/footerLogo.png" width={90} height={40} alt="Picklab 로고" />
+            <Image src="/imgs/footer_Logo.png" width={90} height={40} alt="Picklab 로고" />
           </Link>
 
           {/* Navigation Groups */}

--- a/src/components/common/List/ListItem.tsx
+++ b/src/components/common/List/ListItem.tsx
@@ -83,12 +83,12 @@ const ListItem = ({
     label &&
     saveCount &&
     viewCount && (
-      <div className="flex flex-col gap-space-base py-space-base max-w-[268px]">
+      <div className="flex flex-col justify-between h-full py-space-base max-w-[240px]">
         <div className="flex flex-col gap-space-base">
           <Typography type="Body4Medium" className={`${grayText} truncate`}>
             {label}
           </Typography>
-          <Typography type="Body1Semibold" className={`${grayTextStrong} truncate`}>
+          <Typography type="Body1Semibold" className={`${grayTextStrong} line-clamp-2 break-keep`}>
             {title}
           </Typography>
         </div>
@@ -116,16 +116,17 @@ const ListItem = ({
   return (
     <div
       className={clsx(
-        'flex justify-between items-center cursor-pointer border-b border-gray-20 focus:outline-none',
-        isFinished ? 'py-space-base' : 'py-space-14',
+        'flex justify-between cursor-pointer border rounded-lg border-gray-20 focus:outline-none ',
+        isFinished ? 'p-space-base' : 'py-space-10 px-3',
+        'min-w-[414px]',
       )}
       role="button"
       tabIndex={0}
       onClick={onListClick}
       onKeyDown={handleKeyDown}
     >
-      <div className={clsx('flex gap-space-14 items-start group', isFinished ? 'min-w-[368px]' : 'min-w-[488px]')}>
-        <div className={clsx('w-[86px] relative overflow-hidden', isFinished ? 'h-[94px]' : 'h-[86px]')}>
+      <div className={clsx('flex gap-space-14 items-start group')}>
+        <div className={clsx('w-[86px] relative overflow-hidden', isFinished ? 'h-[94px]' : 'h-[110px]')}>
           <Image src={thumbnail} alt="리스트 썸네일" sizes="86" fill className="object-cover rounded-lg" />
         </div>
         {isFinished ? renderFinishedContent() : renderOngoingContent()}
@@ -134,7 +135,7 @@ const ListItem = ({
         <Icon
           icon={isBookmarked ? 'bookmarkFill' : 'bookmarkLine'}
           size={24}
-          className={clsx('cursor-pointer outline-none', isBookmarked ? 'text-primary-50' : 'text-gray-40')}
+          className={clsx('cursor-pointer outline-none mt-1', isBookmarked ? 'text-primary-50' : 'text-gray-40')}
           onClick={(e) => {
             e.stopPropagation();
             onBookmarkClick?.();

--- a/src/components/common/List/mobile/MoList.tsx
+++ b/src/components/common/List/mobile/MoList.tsx
@@ -48,14 +48,11 @@ const MoList = ({
     >
       <div className="flex gap-3 w-[250px] h-full items-center">
         {/* image */}
-        <Image
-          placeholder="empty"
-          src={imageSrc}
-          alt="리스트 썸네일"
-          width={57}
-          height={64}
-          className="rounded-lg object-cover"
-        />
+        {/* 이미지 width height 뚫고 나와 왜그래? */}
+        <div className="relative w-[57px] h-[64px]">
+          <Image placeholder="empty" src={imageSrc} alt="리스트 썸네일" fill className="rounded-lg" />
+        </div>
+
         <div className="flex flex-col gap-1 h-full justify-center min-w-0 flex-1">
           {/* Caption3Regular로 수정 */}
           <Typography type="Caption2Regular" className="text-gray-90 truncate">

--- a/src/components/common/Select/Select.tsx
+++ b/src/components/common/Select/Select.tsx
@@ -25,16 +25,18 @@ export interface SelectProps {
   onChange: (value?: string | string[]) => void;
   type?: OptionGroupProps['type'];
   disabled?: boolean;
-  width?: 'default' | 'large' | 'small';
-  size?: 'default' | 'small';
+  width?: 'default' | 'large' | 'small' | 'xsmall';
+  size?: 'default' | 'small' | 'xsmall';
   icon?: IconType;
   functionOptionType?: Exclude<FunctionOptionProps['type'], 'selfplus'>;
+  className?: string;
 }
 
 export const widthClassMap = {
   default: 'w-60',
   large: 'w-[420px]',
   small: 'w-[140px]',
+  xsmall: 'w-[98px]',
 };
 
 export const sizeClassMap = {
@@ -45,6 +47,10 @@ export const sizeClassMap = {
   small: {
     button: 'h-space-40',
     optionGroup: 'top-10',
+  },
+  xsmall: {
+    button: 'h-space-34',
+    optionGroup: 'top-8',
   },
 };
 
@@ -63,6 +69,7 @@ const Select = ({
   size = 'default',
   functionOptionType,
   icon,
+  className,
 }: SelectProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const isCheckBox = type === 'checkbox';
@@ -128,6 +135,7 @@ const Select = ({
           selectedLabel && 'border-gray-50 text-gray-90',
           widthClass,
           sizeClass['button'],
+          className,
         )}
         onClick={toggleDropdown}
         disabled={disabled}
@@ -155,7 +163,7 @@ const Select = ({
             'absolute z-10 bottom-4',
             widthClass,
             sizeClass['optionGroup'],
-            label ? (size === 'small' ? 'top-[68px]' : 'top-[76px]') : '',
+            label ? (size === 'small' ? 'top-[68px]' : size === 'xsmall' ? 'top-[60px]' : 'top-[76px]') : '',
           )}
         >
           <OptionGroup

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -16,6 +16,10 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      screens: {
+        mobile: { max: '1439px' },
+        pc: { min: '1440px' },
+      },
       fontFamily: {
         sans: ['Pretendard-Regular', ...defaultTheme.fontFamily.sans],
       },


### PR DESCRIPTION
## 유형

- [ ] 기능 구현
- [x] UI 구현
- [ ] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용
- pc버전 퍼블리싱
- mobile 버전 퍼블리싱
- home 정의
- list, moList 피그마 반영 누락 및 이미지 깨짐 수정
- select xsmall 추가 (mobile)



## 스크린샷
<img width="489" height="727" alt="image" src="https://github.com/user-attachments/assets/f4baa3c9-42bc-46f8-8a81-4741ec4fd0e2" />


## 리뷰 요구사항
- home 디렉토리 구조를 정의해봤습니다. 다른 라우트의 생각은 안했고 mobile과 pc 컴포넌트를 하나의 컴포넌트로 컨트롤 하기가 쉽지 않아 과감하게 pc와 mobile 폴더로 나뉘어 분리했고 공통으로 사용할 부분은 바깥 폴더로 뺐습니다! (ex Banner 컴포넌트)
- 급하게 짜다보니 분명 수정사항이 필요할 것 같아 보이는데 저도 다시 확인해보겠습니다! 한번 확인 부탁드리겠습니다
