### PR TITLE
feat[profile]: 프로필 계정관리 페이지 개발

### DIFF
--- a/src/app/(home)/profile/account/_components/MobileAccountPage.tsx
+++ b/src/app/(home)/profile/account/_components/MobileAccountPage.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import Button from '@/components/common/Button/Button';
+import Switch from '@/components/common/Control/Switch';
+import Avatar from '@/components/common/GNB/pc/Avatar';
+import ChevronRight from '@/components/common/Icon/assets/ChevronRight';
+import TextLink from '@/components/common/TextLink/TextLink';
+import Typography from '@/components/common/Typography';
+import clsx from 'clsx';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+export default function MobileAccountPage() {
+  const [snbMenu, setSnbMenu] = useState<'my-activity' | 'my-post' | 'account'>('my-activity');
+  const router = useRouter();
+
+  return (
+    <div className="block pc:hidden w-full flex flex-col items-center gap-8">
+      {/* 프로필 */}
+      <section className="flex flex-row gap-4 items-center">
+        <Avatar className="w-20 h-20" scale="lg" />
+        <div className="flex flex-col w-[238.5px]">
+          <button className="flex flex-row items-center gap-2 w-full py-4 text-gray-90">
+            <Typography type="Heading2Semibold">이름이름</Typography>
+            <ChevronRight width={7.5} height={13.5} />
+          </button>
+          {/*TODO: 메뉴 1,2,3.. 코딩 해둔거 수정하면서 마지막 menu만 map 함수에서 -> border 없이 or Divder 활용 && hidden */}
+          <div className="flex flex-row flex-wrap gap-1 w-full text-primary-60">
+            <span className="flex items-center h-[20px] pr-3 border-r border-gray-20">
+              <Typography type="Caption1Regular">메뉴 1</Typography>
+            </span>
+            <span className="flex items-center h-[20px] pr-3 border-r border-gray-20">
+              <Typography type="Caption1Regular">메뉴 2</Typography>
+            </span>
+            <span className="flex items-center h-[20px] pr-3 border-r border-gray-20">
+              <Typography type="Caption1Regular">메뉴 3</Typography>
+            </span>
+            <span className="flex items-center h-[20px] pr-3 border-r border-gray-20">
+              <Typography type="Caption1Regular">메뉴 4</Typography>
+            </span>
+            <span className="flex items-center h-[20px] pr-3">
+              <Typography type="Caption1Regular">메뉴 5</Typography>
+            </span>
+          </div>
+        </div>
+      </section>
+
+      {/*snb menu */}
+      <div className="flex flex-row w-full">
+        <Link
+          href="#1"
+          id="my-activity"
+          className={clsx(
+            'box-border w-full flex px-space-10 h-space-48 justify-center border-b-[1.5px] border-gray-30',
+            snbMenu === 'my-activity' && '!border-primary-50 !border-b-[3px]',
+          )}
+          onClick={() => setSnbMenu('my-activity')}
+        >
+          <Typography type="Headline2SemiBold">MY 활동</Typography>
+        </Link>
+        <Link
+          href="#2"
+          id="my-post"
+          className={clsx(
+            'box-border w-full flex px-space-10 h-space-48 justify-center border-b-[1.5px] border-gray-30',
+            snbMenu === 'my-post' && '!border-primary-50 !border-b-[3px]',
+          )}
+          onClick={() => setSnbMenu('my-post')}
+        >
+          <Typography type="Headline2SemiBold">게시물</Typography>
+        </Link>
+        <Link
+          href="#3"
+          id="account"
+          className={clsx(
+            'box-border w-full flex px-space-10 h-space-48 justify-center border-b-[1.5px] border-gray-30',
+            snbMenu === 'account' && '!border-primary-50 !border-b-[3px]',
+          )}
+          onClick={() => setSnbMenu('account')}
+        >
+          <Typography type="Headline2SemiBold">계정</Typography>
+        </Link>
+      </div>
+
+      {/*알림 관리 */}
+      <section className="w-full flex flex-col gap-5 w-full p-4 border border-gray-20 rounded-[10px]">
+        <div className="pb-3 border-b border-gray-20">
+          <Typography type="Heading2Semibold">알림 관리</Typography>
+        </div>
+        <div className="flex flex-col gap-5">
+          <div className="w-full flex flex-row justify-between py-1">
+            <div className="flex flex-col gap-1">
+              <Typography type="Headline2SemiBold">인기 공고</Typography>
+              <Typography type="Caption1Regular" className="text-gray-60">
+                사용자의 관심 직무 관련 인기 공고의 알림입니다.
+              </Typography>
+            </div>
+            <div>
+              <Switch />
+            </div>
+          </div>
+          <div className="w-full flex flex-row justify-between py-1">
+            <div className="flex flex-col gap-1">
+              <Typography type="Headline2SemiBold">저장한 공고</Typography>
+              <Typography type="Caption1Regular" className="text-gray-60">
+                사용자의 관심 직무 관련 저장한 공고의 알림입니다.
+              </Typography>
+            </div>
+            <div>
+              <Switch />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/*계정 관리 */}
+      <section className="w-full flex flex-col gap-7 items-end">
+        <div className="flex flex-col gap-5 w-full p-4 border border-gray-20 rounded-[10px]">
+          <div className="pb-3 border-b border-gray-20">
+            <Typography type="Heading2Semibold">계정 관리</Typography>
+          </div>
+          <div className="flex flex-col gap-5">
+            <div className="w-full flex flex-row justify-between py-1">
+              <div className="flex flex-col gap-1">
+                <Typography type="Headline2SemiBold">이메일</Typography>
+                <Typography type="Body3Medium" className="text-gray-60">
+                  test@test.com
+                </Typography>
+              </div>
+              <div>
+                <Button
+                  size="sm"
+                  buttonStyle="outlined"
+                  label="변경하기"
+                  isFullRounded={true}
+                  onClick={() => router.push('/change-email')}
+                />
+              </div>
+            </div>
+            <div className="w-full flex flex-row justify-between py-1">
+              <div className="flex flex-col gap-1">
+                <Typography type="Headline2SemiBold">이메일 마케팅 수신 동의</Typography>
+                <Typography type="Caption1Regular" className="text-gray-60">
+                  이벤트, 혜택, 신규 서비스를 알려드립니다.
+                </Typography>
+              </div>
+              <div>
+                <Switch />
+              </div>
+            </div>
+          </div>
+        </div>
+        <TextLink text="회원 탈퇴" href="/profile/account/withdraw" />
+      </section>
+    </div>
+  );
+}

--- a/src/app/(home)/profile/account/_components/PcAccountPage.tsx
+++ b/src/app/(home)/profile/account/_components/PcAccountPage.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import Button from '@/components/common/Button/Button';
+import Switch from '@/components/common/Control/Switch';
+import SNB from '@/components/common/SNB/SNB';
+import TextLink from '@/components/common/TextLink/TextLink';
+import Typography from '@/components/common/Typography';
+import { useRouter } from 'next/navigation';
+
+export default function PcAccountPage() {
+  const router = useRouter();
+
+  return (
+    <div className="hidden pc:flex gap-12.5 flex-row w-[1100px] px-5">
+      <SNB Jobs={[]} />
+
+      {/* 계정 관리 섹션 */}
+      <section className="flex flex-col gap-12 items-end">
+        <div className="w-[750px] ml-10 px-10 py-8 border border-gray-20 rounded-[10px] flex flex-col gap-8">
+          <div className="w-full flex flex-col pb-3 border-b border-gray-20">
+            <Typography type="Heading1Semibold" className="text-gray-90">
+              계정 관리
+            </Typography>
+          </div>
+          <div className="w-full flex flex-col gap-5">
+            <div className="w-full flex flex-row justify-between py-1">
+              <div className="w-full flex flex-col gap-1">
+                <Typography type="Headline2SemiBold" className="text-gray-100">
+                  이메일
+                </Typography>
+                <Typography type="Body3Medium" className="text-gray-60">
+                  kjyook01@gmail.com
+                </Typography>
+              </div>
+              <Button
+                size="sm"
+                buttonStyle="outlined"
+                label="변경하기"
+                isFullRounded={true}
+                onClick={() => router.push('/change-email')}
+              />
+            </div>
+            <div className="flex flex-row justify-between py-1 w-full">
+              <div className="w-full flex flex-col gap-1">
+                <Typography type="Headline2SemiBold">이메일 마케팅 수신 동의</Typography>
+                <Typography type="Caption1Regular" className="text-gray-60">
+                  이벤트, 혜택, 신규 서비스를 알려드립니다.
+                </Typography>
+              </div>
+              <Switch />
+            </div>
+          </div>
+        </div>
+        <TextLink text="회원 탈퇴" href="/profile/account/withdraw" />
+      </section>
+    </div>
+  );
+}

--- a/src/app/(home)/profile/account/page.tsx
+++ b/src/app/(home)/profile/account/page.tsx
@@ -1,0 +1,11 @@
+import MobileAccountPage from './_components/MobileAccountPage';
+import PcAccountPage from './_components/PcAccountPage';
+
+export default function AccountPage() {
+  return (
+    <>
+      <PcAccountPage />
+      <MobileAccountPage />
+    </>
+  );
+}

--- a/src/app/(home)/profile/account/withdraw/_components/WithdrawPage.tsx
+++ b/src/app/(home)/profile/account/withdraw/_components/WithdrawPage.tsx
@@ -1,0 +1,89 @@
+import Button from '@/components/common/Button/Button';
+import CheckBoxLabel from '@/components/common/CheckBox/CheckBoxLabel';
+import RadioLabel from '@/components/common/Control/RadioLabel';
+import Typography from '@/components/common/Typography';
+
+export default function WithdrawPage() {
+  return (
+    <div className="flex flex-col items-center max-w-[1440px]">
+      <div className="h-[1297px] w-full max-w-[460px] flex flex-col gap-10 pt-10 pb-30 mx-auto">
+        <div className="w-full h-[1049px] flex flex-col gap-12">
+          {/*회원 탈퇴 안내 */}
+          <section className="flex flex-col w-full gap-[38px] pc:pb-12 pc:border-b pc:border-gray-20">
+            <div className="w-full flex flex-col items-center gap-2">
+              <Typography type="Title2Bold">탈퇴안내</Typography>
+              <Typography type="Body2Medium">PICKLAB 회원탈퇴를 신청하기 전 안내사항을 꼭 확인해주세요!</Typography>
+            </div>
+            <div className="w-full flex flex-col gap-2">
+              <div className="w-full flex flex-col gap-1 py-[22px] px-5 rounded-[8px] bg-gray-10">
+                <Typography type="Body2Semibold">탈퇴한 계정은 복구 및 재사용이 불가능</Typography>
+                <Typography type="Caption2Regular">
+                  본인을 포함해 누구도 다시 사용할 수 없으니 신중하게 결정해 주세요.
+                </Typography>
+              </div>
+              <div className="w-full flex flex-col gap-1 py-[22px] px-5 rounded-[8px] bg-gray-10">
+                <Typography type="Body2Semibold">개인정보 및 이용 기록 복구 불가능</Typography>
+                <Typography type="Caption2Regular">
+                  회원님의 개인정보 및 이용 기록은 모두 삭제되며 복구할 수 없습니다.
+                </Typography>
+              </div>
+              <div className="w-full flex flex-col gap-1 py-[22px] px-5 rounded-[8px] bg-gray-10">
+                <Typography type="Body2Semibold">리뷰와 댓글은 직접 삭제</Typography>
+                <Typography type="Caption2Regular">
+                  PICKLAB에 작성하신 리뷰와 댓글은 탈퇴 후에도 남아 있으니 필요한 경우 직접 삭제해 주세요.
+                </Typography>
+              </div>
+              <div className="w-full flex flex-col gap-1 py-[22px] px-5 rounded-[8px] bg-gray-10">
+                <Typography type="Body2Semibold">개인정보는 탈퇴 후 30일간만 보관</Typography>
+                <Typography type="Caption2Regular">
+                  개인정보는 탈퇴일로부터 30일간 보관 후 개인정보처리방침에 따라 안전하게 삭제됩니다.
+                </Typography>
+              </div>
+            </div>
+            <CheckBoxLabel id="withdrawal-agreement" value="" label="위 안내사항을 확인했으며, 동의합니다." />
+          </section>
+
+          {/*회원 탈퇴 사유 */}
+          <section className="flex flex-col w-full gap-12">
+            <div className="w-full flex flex-col gap-2 items-center">
+              <Typography type="Title2Bold">탈퇴사유</Typography>
+              <Typography type="Body2Medium">PICKLAB을 탈퇴하시는 이유를 알려주세요.</Typography>
+            </div>
+            <div className="flex flex-col gap-5 w-full">
+              <RadioLabel
+                label="원하는 활동 정보가 부족해요"
+                id="reason-1"
+                name="withdrawal-reason"
+                value="insufficient-info"
+              />
+              <RadioLabel
+                label="리뷰/정보 신뢰도가 낮다고 느꼈어요."
+                id="reason-2"
+                name="withdrawal-reason"
+                value="low-trust"
+              />
+              <RadioLabel
+                label="이용 방법이 복잡하거나 불편했어요."
+                id="reason-3"
+                name="withdrawal-reason"
+                value="inconvenience"
+              />
+              <RadioLabel
+                label="비슷한 다른 서비스를 이용하고 있어요."
+                id="reason-4"
+                name="withdrawal-reason"
+                value="other-services"
+              />
+              <RadioLabel label="서비스 오류나 버그가 많았어요." id="reason-5" name="withdrawal-reason" value="bugs" />
+              <RadioLabel label="기타" id="reason-6" name="withdrawal-reason" value="other" />
+            </div>
+          </section>
+          <div className="w-full flex flex-row gap-[10px]">
+            <Button size="lg" buttonStyle="outlined" label="취소" className="flex-grow" />
+            <Button size="lg" buttonStyle="filled" label="탈퇴하기" className="flex-grow" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(home)/profile/account/withdraw/page.tsx
+++ b/src/app/(home)/profile/account/withdraw/page.tsx
@@ -1,0 +1,9 @@
+import WithdrawPage from './_components/WithdrawPage';
+
+export default function WithdrawPageWrapper() {
+  return (
+    <>
+      <WithdrawPage />
+    </>
+  );
+}

--- a/src/app/@modal/change-email/page.tsx
+++ b/src/app/@modal/change-email/page.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import Button from '@/components/common/Button/Button';
+import TextField from '@/components/common/Field/TextField';
+import CustomModal from '@/components/common/Modal/CustomModal';
+import useModal from '@/hooks/useModal';
+
+export default function Page() {
+  const { closeModal } = useModal();
+  return (
+    <CustomModal
+      isOpen={true}
+      onClose={closeModal}
+      onSuccess={() => console.log('success')}
+      title="이메일 변경"
+      width={532}
+      backdropClose={false}
+    >
+      <div className="flex flex-col w-full gap-5">
+        <div className="flex flex-row gap-[7px] items-center w-full h-[104px]">
+          <TextField
+            id="email-verification"
+            labelStatus="default"
+            status="disabled"
+            label="이메일 인증"
+            placeholder="이메일을 입력해주세요"
+          />
+          <Button label="인증요청" size="lg" buttonStyle="outlined" />
+        </div>
+      </div>
+
+      <div className="flex flex-col w-full gap-5">
+        <div className="flex flex-row gap-[7px] items-center w-full h-[104px]">
+          <TextField
+            id="email-verification"
+            labelStatus="default"
+            status="disabled"
+            label="인증번호"
+            placeholder="인증번호를 입력해주세요"
+          />
+          <Button label="확인하기" size="lg" buttonStyle="outlined" />
+        </div>
+      </div>
+    </CustomModal>
+  );
+}

--- a/src/components/common/Modal/CustomModal.tsx
+++ b/src/components/common/Modal/CustomModal.tsx
@@ -1,0 +1,109 @@
+// components/Modal.tsx
+'use client';
+
+import Button from '@/components/common/Button/Button';
+import Icon from '@/components/common/Icon/Icon';
+import Typography from '@/components/common/Typography';
+import React, { useEffect, useRef } from 'react';
+
+export interface ModalProps {
+  children?: React.ReactNode;
+  width?: number;
+  isOpen: boolean;
+  title: string;
+  description?: string;
+  backdropClose?: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+const CustomModal = ({
+  isOpen,
+  onClose,
+  onSuccess,
+  title,
+  description,
+  backdropClose = true,
+  width = 360,
+  children,
+}: ModalProps) => {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const modalWidth = `w-[${width}px]`;
+
+  // ESC 키로 닫기
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    if (isOpen) window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [isOpen, onClose]);
+
+  // 포커스 트랩
+  useEffect(() => {
+    if (isOpen && closeButtonRef.current) {
+      closeButtonRef.current.focus();
+    }
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  const onSuccessHandler = () => {
+    onSuccess();
+    onClose();
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-10 flex items-center justify-center bg-gray-100/40"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="modal-title"
+      aria-describedby="modal-description"
+    >
+      <div
+        ref={dialogRef}
+        className={`flex flex-col bg-gray-0 rounded-2xl px-14 py-[26px] gap-11 ${modalWidth}`}
+        tabIndex={-1}
+      >
+        {/* Header */}
+        {backdropClose && (
+          <div className="flex justify-end">
+            <button
+              ref={closeButtonRef}
+              onClick={onClose}
+              aria-label="닫기"
+              className="flex justify-center items-center size-6"
+            >
+              <Icon icon="exit" size={12} className="text-gray-90" />
+            </button>
+          </div>
+        )}
+
+        <div className="flex flex-col gap-space-32">
+          {/* Body */}
+          <div className="flex flex-col items-center justify-center gap-space-6">
+            <Typography tag="h1" type="Heading1Semibold" id="modal-title" className="text-gray-90">
+              {title}
+            </Typography>
+            {description && (
+              <Typography tag="p" type="Body4Regular" id="modal-description" className="text-gray-50">
+                {description}
+              </Typography>
+            )}
+            {children}
+          </div>
+
+          {/* Footer */}
+          <div className="flex gap-2">
+            <Button className="w-full" buttonStyle="outlined" size="base" label="취소" onClick={onClose} />
+
+            <Button className="w-full" buttonStyle="filled" size="base" label="확인" onClick={onSuccessHandler} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+export default CustomModal;

--- a/src/components/common/SNB/SNB.tsx
+++ b/src/components/common/SNB/SNB.tsx
@@ -38,7 +38,7 @@ const SNB = ({ Jobs }: SNBProps) => {
   const isSubActive = (pathname: string, subHref: string) => pathname === subHref;
 
   return (
-    <aside className="w-[260px] h-[960px] px-6 flex flex-col" aria-label="사이드 내비게이션">
+    <aside className="w-[260px] h-[960px] px-6 flex flex-col border-r border-gray-20" aria-label="사이드 내비게이션">
       {/* 프로필 영역 */}
       <section className="flex flex-col h-[202px] pt-space-10 border-b" aria-labelledby="profile-heading">
         <div className="flex flex-col h-30 gap-[18px] items-center">


### PR DESCRIPTION
## 유형

- [ ] 기능 구현
- [0] UI 구현
- [ ] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용
---
- 계정관리 페이지 개발

### 설명 (선택)

pc mobile layout이 달라서 분리하여 개발, 해당 컴포넌트 상단에 block or hidden 작성
email validate을 위한 modal을 기존 modal 을 활용하여 custom하여 확장함
탈퇴하기 전 들어가는 탈퇴 페이지 작성

## 스크린샷

<img width="1416" height="733" alt="image" src="https://github.com/user-attachments/assets/8ef27673-4796-492d-a69f-4bdd86216817" />
<img width="356" height="621" alt="image" src="https://github.com/user-attachments/assets/c80a5dd5-44d5-4202-a290-485fe5b2d278" />
<img width="613" height="826" alt="image" src="https://github.com/user-attachments/assets/6b0ef933-12ea-4144-a098-4c41181f54f5" />

<img width="323" height="646" alt="image" src="https://github.com/user-attachments/assets/14bb8ae1-a166-47e9-89f0-5b78d5ea0b52" />


## 리뷰 요구사항

- modal을 custom 하여 새로 작성한 부분
- 전체적인 ui가 디지안이랑 적합한지

---
### 추후 추가사항
- email modal에 help text 작성
- data 적용
- pc & mobile 모두 menu 클릭에 따른 link 변경
